### PR TITLE
Container image

### DIFF
--- a/.github/assets/openmower_entrypoint.sh
+++ b/.github/assets/openmower_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+source /opt/openmower/ROS/devel/setup.bash
+
+exec "$@"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,47 @@
+name: Build
+
+# Controls when the workflow will run
+on:
+  workflow_dispatch
+  push:
+    branches:
+      - 'main'
+      - 'dev'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'dev'
+
+# permissions are needed if pushing to ghcr.io
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Get the repository's code
+      - name: Checkout
+        uses: actions/checkout@v2
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -2,13 +2,10 @@ name: Build
 
 # Controls when the workflow will run
 on:
-  workflow_dispatch
   push:
     branches:
       - 'main'
       - 'dev'
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -42,4 +42,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{github.repository}}/${{secrets.REPO}}:latest
+          tags: ${{github.repository}}:latest

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -42,3 +42,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{github.repository}}/${{secrets.REPO}}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ros:noetic-ros-base
+
+RUN rosdep update
+RUN apt update && \
+    apt install -y git
+
+RUN git clone --recurse-submodules https://github.com/ClemensElflein/OpenMower /opt/openmower
+
+WORKDIR /opt/openmower/ROS
+RUN rosdep install --from-paths src --ignore-src -y
+RUN bash -c "source "/opt/ros/$ROS_DISTRO/setup.bash" && catkin_make"
+
+COPY .github/assets/openmower_entrypoint.sh /openmower_entrypoint.sh
+RUN chmod +x /openmower_entrypoint.sh
+
+ENTRYPOINT ["/openmower_entrypoint.sh"]
+CMD ["roslaunch", "open_mower", "open_mower.launch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ros:noetic-ros-base
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN rosdep update
 RUN apt update && \
     apt install -y git


### PR DESCRIPTION
Happy to share container image I use to get things done. It's based on an official ROS' noetic base image. This has to be considered for development purposes only as it is not optimised (no multistage build, hence size is big) and does not guarantee security.

Build will be automatically triggered with Github Actions and pushed with two amd64, arm64 targets

Container runs a `roslaunch open_mower open_mower.launch` by default, unless any other CMD is provided.
It's possible to run any ROS command or bash shell.

While working on this, it came to my attention that the setup of having ROS workspace in main Open Mower repository is not sustainable - as open mower package (in this repository) is not designed to run separately.
IMO this repository should contain whole ROS workspace. Walk-around for the build is to clone main repository during the image build.

Next steps:

- [ ] provide quick introduction in README
- [ ] how to run container on RPi
- [ ] how to run container on macOS (with X11 forwarding)