### PR TITLE
Fix image push by removing default image name

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,7 +28,6 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ${{github.repository}}
             ghcr.io/${{github.repository}}
           # generate Docker tags based on the following events/attributes
           tags: |


### PR DESCRIPTION
This should solve an issue with image push. Image tagged with no explicit host is being pushed to Dockerhub by default. We want this in Github registry.