### PR TITLE
Add boolean topics for recording control

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
@@ -143,7 +143,6 @@ void AreaRecordingBehavior::enter() {
     markers = visualization_msgs::MarkerArray();
 
 
-
     add_mowing_area_client = n->serviceClient<mower_map::AddMowingAreaSrv>("mower_map_service/add_mowing_area");
     set_docking_point_client = n->serviceClient<mower_map::SetDockingPointSrv>("mower_map_service/set_docking_point");
 
@@ -154,8 +153,14 @@ void AreaRecordingBehavior::enter() {
     ROS_INFO_STREAM("Starting recording area");
 
     ROS_INFO_STREAM("Subscribing to /joy for user input");
-    joy_sub = n->subscribe("/joy", 100,
-                                          &AreaRecordingBehavior::joy_received, this);
+    
+    joy_sub = n->subscribe("/joy", 100, &AreaRecordingBehavior::joy_received, this);
+
+    dock_sub = n->subscribe("/record_dock", 100, &AreaRecordingBehavior::record_dock_received, this);
+    polygon_sub = n->subscribe("/record_polygon", 100, &AreaRecordingBehavior::record_polygon_received, this);
+    mow_area_sub = n->subscribe("/record_mowing", 100, &AreaRecordingBehavior::record_mowing_received, this);
+    nav_area_sub = n->subscribe("/record_navigation", 100, &AreaRecordingBehavior::record_navigation_received, this);
+
     odom_sub = n->subscribe("mower/odom", 100,
                                            &AreaRecordingBehavior::odom_received, this);
 
@@ -165,6 +170,10 @@ void AreaRecordingBehavior::exit() {
     marker_pub.shutdown();
     marker_array_pub.shutdown();
     joy_sub.shutdown();
+    dock_sub.shutdown();
+    polygon_sub.shutdown();
+    mow_area_sub.shutdown();
+    nav_area_sub.shutdown();
     odom_sub.shutdown();
     add_mowing_area_client.shutdown();
     set_docking_point_client.shutdown();
@@ -224,6 +233,45 @@ void AreaRecordingBehavior::joy_received(const sensor_msgs::Joy &joy_msg) {
 
 
     last_joy = joy_msg;
+}
+
+void AreaRecordingBehavior::record_dock_received(std_msgs::Bool state_msg) {
+    if (state_msg.data) {
+        ROS_INFO_STREAM("Record dock position");
+        set_docking_position = true;
+    }
+}
+
+void AreaRecordingBehavior::record_polygon_received(std_msgs::Bool state_msg) {
+    if (state_msg.data) {
+        // We toggle recording state
+        ROS_INFO_STREAM("Toggle record polygon");
+        poly_recording_enabled = !poly_recording_enabled;
+    }
+}
+
+void AreaRecordingBehavior::record_navigation_received(std_msgs::Bool state_msg) {
+    if (state_msg.data) {
+        ROS_INFO_STREAM("Save polygon as navigation area");
+        // stop current poly recording
+        poly_recording_enabled = false;
+
+        // set finished
+        is_mowing_area = false;
+        finished_all = true;
+    }
+}
+
+void AreaRecordingBehavior::record_mowing_received(std_msgs::Bool state_msg) {
+    if (state_msg.data) {
+        ROS_INFO_STREAM("Save polygon as mowing area");
+        // stop current poly recording
+        poly_recording_enabled = false;
+
+        // set finished
+        is_mowing_area = true;
+        finished_all = true;
+    }
 }
 
 

--- a/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.h
@@ -41,12 +41,15 @@
 
 #include "geometry_msgs/Twist.h"
 
+#include "std_msgs/Bool.h"
+
 class AreaRecordingBehavior : public Behavior {
 public:
     static AreaRecordingBehavior INSTANCE;
 private:
 
     bool has_odom = false;
+
 
     sensor_msgs::Joy last_joy;
     nav_msgs::Odometry last_odom;
@@ -55,6 +58,8 @@ private:
     ros::Publisher marker_array_pub;
 
     ros::Subscriber joy_sub, odom_sub;
+
+    ros::Subscriber dock_sub, polygon_sub, mow_area_sub, nav_area_sub;
 
     ros::ServiceClient add_mowing_area_client, set_docking_point_client;
 
@@ -75,8 +80,12 @@ private:
 private:
     bool recordNewPolygon(geometry_msgs::Polygon &polygon);
     bool getDockingPosition(geometry_msgs::Pose &pos);
-    void joy_received(const sensor_msgs::Joy &joy_msg);
     void odom_received(const nav_msgs::Odometry &odom_msg);
+    void joy_received(const sensor_msgs::Joy &joy_msg);
+    void record_dock_received(std_msgs::Bool state_msg);
+    void record_polygon_received(std_msgs::Bool state_msg);
+    void record_mowing_received(std_msgs::Bool state_msg);
+    void record_navigation_received(std_msgs::Bool state_msg);
 
 public:
     std::string state_name() override;

--- a/src/open_mower/launch/gamepad_remote_control.launch
+++ b/src/open_mower/launch/gamepad_remote_control.launch
@@ -4,19 +4,7 @@
 <launch>
     <include file="$(find open_mower)/launch/include/_comms.launch"/>
     <include file="$(find open_mower)/launch/include/_localization.launch"/>
+    <include file="$(find open_mower)/launch/include/_teleop.launch"/>
 
     <node pkg="mower_map" type="mower_map_service" name="map_service" output="screen"/>
-
-    <node name="joy" pkg="joy" type="joy_node">
-        <param name="~autorepeat_rate" value="10.0"/>
-        <param name="~coalesce_interval" value="0.06"/>
-    </node>
-    
-    <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node" required="true" >
-        <param name="~scale_linear" value="0.5"/>
-        <param name="~scale_angular" value="1.5"/>
-        <param name="~scale_linear_turbo" value="1.0"/>
-        <param name="~scale_angular_turbo" value="3.0"/>
-        <param name="~enable_turbo_button" value="4"/>
-    </node>
 </launch>

--- a/src/open_mower/launch/include/_teleop.launch
+++ b/src/open_mower/launch/include/_teleop.launch
@@ -1,14 +1,30 @@
 <launch>
-    <node name="joy" pkg="joy" type="joy_node">
-        <param name="~autorepeat_rate" value="10.0"/>
-        <param name="~coalesce_interval" value="0.06"/>
-    </node>
+    <group if="$(eval env('OM_MOWER_GAMEPAD') == 'xbox360')">
+        <node name="joy" pkg="joy" type="joy_node">
+            <param name="~autorepeat_rate" value="10.0"/>
+            <param name="~coalesce_interval" value="0.06"/>
+        </node>
 
-    <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node">
-        <param name="~scale_linear" value="0.5"/>
-        <param name="~scale_angular" value="0.5"/>
-        <param name="~scale_linear_turbo" value="1.0"/>
-        <param name="~scale_angular_turbo" value="1.0"/>
-        <param name="~enable_turbo_button" value="4"/>
-    </node>
+        <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node">
+            <param name="~scale_linear" value="0.5"/>
+            <param name="~scale_angular" value="0.5"/>
+            <param name="~scale_linear_turbo" value="1.0"/>
+            <param name="~scale_angular_turbo" value="1.0"/>
+            <param name="~enable_turbo_button" value="4"/>
+        </node>
+    </group>
+
+    <group unless="$(eval env('OM_MOWER_GAMEPAD') == 'xbox360')">
+        <node name="joy" pkg="joy" type="joy_node" required="true" >
+            <remap from="/joy" to="/teleop_joy"/>
+            <param name="~coalesce_interval" value="0.06"/>
+        </node>
+        
+        <rosparam file="$(find open_mower)/params/gamepads/$(env OM_MOWER_GAMEPAD).yaml" command="load"/>
+        
+        <node name="joy_teleop" pkg="joy_teleop" type="joy_teleop.py" required="true">
+            <remap from="/joy" to="/teleop_joy"/>
+        </node>
+    </group>
+
 </launch>

--- a/src/open_mower/launch/open_mower.launch
+++ b/src/open_mower/launch/open_mower.launch
@@ -2,10 +2,10 @@
     <include file="$(find open_mower)/launch/include/_comms.launch"/>
     <include file="$(find open_mower)/launch/include/_move_base.launch"/>
     <include file="$(find open_mower)/launch/include/_localization.launch"/>
+    <include file="$(find open_mower)/launch/include/_teleop.launch"/>
     <include file="$(find open_mower)/launch/include/_record.launch">
         <arg name="prefix" value="mow_area"/>
     </include>
-
 
     <node pkg="mower_map" type="mower_map_service" name="map_service" output="screen"/>
     <node pkg="mower_logic" type="mower_logic" name="mower_logic" output="screen">
@@ -21,25 +21,9 @@
     </node>
     <node pkg="slic3r_coverage_planner" type="slic3r_coverage_planner" name="slic3r_coverage_planner" output="screen"/>
 
-    <node name="joy" pkg="joy" type="joy_node" required="true" >
-        <param name="~autorepeat_rate" value="10.0"/>
-        <param name="~coalesce_interval" value="0.06"/>
-    </node>
-
-    <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node" required="true" >
-        <remap from="cmd_vel" to="joy_vel"/>
-        <param name="~scale_linear" value="0.5"/>
-        <param name="~scale_angular" value="1.5"/>
-        <param name="~scale_linear_turbo" value="1.0"/>
-        <param name="~scale_angular_turbo" value="3.0"/>
-        <param name="~enable_turbo_button" value="4"/>
-    </node>
-
-
     <node pkg="twist_mux" type="twist_mux" name="twist_mux" output="screen">
         <remap from="cmd_vel_out" to="/cmd_vel"/>
 
         <rosparam file="$(find open_mower)/params/twist_mux_topics.yaml"  command="load"/>
     </node>
-
 </launch>

--- a/src/open_mower/launch/remote_rviz.launch
+++ b/src/open_mower/launch/remote_rviz.launch
@@ -1,8 +1,5 @@
 <launch>
-
-    
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find open_mower)/rviz/record_map.rviz" required="true" />
     <node pkg="rqt_reconfigure" type="rqt_reconfigure" name="rqt_reconfigure">
     </node>
-
 </launch>

--- a/src/open_mower/launch/sim_mower_logic.launch
+++ b/src/open_mower/launch/sim_mower_logic.launch
@@ -5,7 +5,7 @@
     <include file="$(find open_mower)/launch/include/_rosbridge.launch" />
     <include file="$(find mower_simulation)/launch/_mower_simulation.launch" />
     <include file="$(find open_mower)/launch/include/_move_base.launch" />
-
+    <include file="$(find open_mower)/launch/include/_teleop.launch"/>
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find open_mower)/rviz/sim_mower_logic.rviz" required="true" />
     <node pkg="mower_map" type="mower_map_service" name="mower_map" required="true" />
@@ -16,24 +16,9 @@
         <param name="gps_wait_time" value="0"/>
         <param name="undock_distance" value="0.1"/>
     </node>
-
-    <node name="joy" pkg="joy" type="joy_node" required="true" >
-        <param name="~autorepeat_rate" value="10.0"/>
-        <param name="~coalesce_interval" value="0.06"/>
-    </node>
-
-    <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node" required="true" >
-        <remap from="cmd_vel" to="joy_vel"/>
-        <param name="~scale_linear" value="0.5"/>
-        <param name="~scale_angular" value="0.5"/>
-        <param name="~scale_linear_turbo" value="1.0"/>
-        <param name="~scale_angular_turbo" value="1.0"/>
-        <param name="~enable_turbo_button" value="4"/>
-    </node>
-
+    
     <node pkg="twist_mux" type="twist_mux" name="twist_mux" output="screen">
         <remap from="cmd_vel_out" to="/cmd_vel"/>
-
-        <rosparam file="$(find open_mower)/params/twist_mux_topics.yaml"  command="load"/>
+        <rosparam file="$(find open_mower)/params/twist_mux_topics.yaml" command="load"/>
     </node>
 </launch>

--- a/src/open_mower/launch/sim_navigation.launch
+++ b/src/open_mower/launch/sim_navigation.launch
@@ -4,19 +4,7 @@
 <launch>
     <include file="$(find mower_simulation)/launch/_mower_simulation.launch" />
     <include file="$(find open_mower)/launch/include/_move_base.launch" />
-
-    <node name="joy" pkg="joy" type="joy_node" required="true" >
-        <param name="~autorepeat_rate" value="10.0"/>
-        <param name="~coalesce_interval" value="0.06"/>
-    </node>
-
-    <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node" required="true" >
-        <param name="~scale_linear" value="0.5"/>
-        <param name="~scale_angular" value="0.5"/>
-        <param name="~scale_linear_turbo" value="1.0"/>
-        <param name="~scale_angular_turbo" value="1.0"/>
-        <param name="~enable_turbo_button" value="4"/>
-    </node>
+    <include file="$(find open_mower)/launch/include/_teleop.launch"/>
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find open_mower)/rviz/sim_navigation_test.rviz" required="true" />
     <node pkg="mower_map" type="mower_map_service" name="mower_map" required="true" />

--- a/src/open_mower/launch/test_playback.launch
+++ b/src/open_mower/launch/test_playback.launch
@@ -9,12 +9,8 @@
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find open_mower)/rviz/playback.rviz" required="true" />
 
-
-
 <!--    <node pkg="open_mower_ros" type="area_recorder" name="area_recorder" output="screen">-->
 <!--    </node>-->
     <node pkg="mower_map" type="mower_map_service" name="map_service" output="screen" />
     <node pkg="rqt_reconfigure" type="rqt_reconfigure" name="rqt_reconfigure" />
-
-
 </launch>

--- a/src/open_mower/params/gamepads/ps3.yaml
+++ b/src/open_mower/params/gamepads/ps3.yaml
@@ -1,0 +1,59 @@
+teleop:
+  move:
+    type: topic
+    message_type: geometry_msgs/Twist
+    topic_name: joy_vel
+    deadman_buttons: [0]
+    axis_mappings:
+      -
+        axis: 1
+        target: linear.x
+        scale: 1
+      -
+        axis: 0
+        target: angular.z
+        scale: 1
+      -
+        axis: 2
+        target: linear.y
+        scale: 1
+  
+  record_polygon:
+    type: topic
+    message_type: std_msgs/Bool
+    topic_name: record_polygon
+    deadman_buttons: [1]
+    message_value:
+      -
+        target: data
+        value: 1
+  
+  record_dock:
+    type: topic
+    message_type: std_msgs/Bool
+    topic_name: record_dock
+    deadman_buttons: [2]
+    message_value:
+      -
+        target: data
+        value: 1
+  
+  record_mowing:
+    type: topic
+    message_type: std_msgs/Bool
+    topic_name: record_mowing
+    deadman_buttons: [3, 14]
+    message_value:
+      -
+        target: data
+        value: 1
+
+  record_navigation:
+    type: topic
+    message_type: std_msgs/Bool
+    topic_name: record_navigation
+    deadman_buttons: [3, 13]
+    message_value:
+      -
+        target: data
+        value: 1


### PR DESCRIPTION
Adds boolean topics in addition to the joy subscription in the area recording behavior to be used with joy_teleop and ROS-Mobile. This also allows setting parameters for multiple gamepads and can be set with the OM_MOWER_GAMEPAD variable" 

Example of ROS-Mobile setup:
![Screenshot_20220829-191310](https://user-images.githubusercontent.com/39061161/187254896-ed3cf46d-e6e5-4bd3-9306-2cd245e4d7e3.png)
