### PR TITLE
Fix missing remap and scaling in teleop. 

### DIFF
--- a/src/mower_msgs/package.xml
+++ b/src/mower_msgs/package.xml
@@ -11,7 +11,7 @@
   <url type="website">https://github.com/ClemensElflein/OpenMower</url>
 
   <build_depend>message_generation</build_depend>
-  <build_depend>vesc_msgs</build_depend>
+  <build_depend>xesc_msgs</build_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/src/open_mower/config/mower_config.sh.example
+++ b/src/open_mower/config/mower_config.sh.example
@@ -11,6 +11,10 @@ export OM_MOWER="YardForce500"
 # Select your ESC type, xesc_mini for the STM32 version or xesc_2040 for the RP2040 version
 export OM_MOWER_ESC_TYPE="xesc_mini"
 
+# Select your gamepad
+# Currently supported: ps3, xbox360
+export OM_MOWER_GAMEPAD="xbox360"
+
 # Set to true to record your session
 # export OM_ENABLE_RECORDING=False
 

--- a/src/open_mower/launch/include/_teleop.launch
+++ b/src/open_mower/launch/include/_teleop.launch
@@ -1,15 +1,16 @@
 <launch>
     <group if="$(eval env('OM_MOWER_GAMEPAD') == 'xbox360')">
-        <node name="joy" pkg="joy" type="joy_node">
+        <node name="joy" pkg="joy" type="joy_node" required="true">
             <param name="~autorepeat_rate" value="10.0"/>
             <param name="~coalesce_interval" value="0.06"/>
         </node>
 
-        <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node">
+        <node name="joy_teleop" pkg="teleop_twist_joy" type="teleop_node" required="true">
+            <remap from="cmd_vel" to="joy_vel"/>
             <param name="~scale_linear" value="0.5"/>
-            <param name="~scale_angular" value="0.5"/>
+            <param name="~scale_angular" value="1.5"/>
             <param name="~scale_linear_turbo" value="1.0"/>
-            <param name="~scale_angular_turbo" value="1.0"/>
+            <param name="~scale_angular_turbo" value="3.0"/>
             <param name="~enable_turbo_button" value="4"/>
         </node>
     </group>
@@ -26,5 +27,4 @@
             <remap from="/joy" to="/teleop_joy"/>
         </node>
     </group>
-
 </launch>


### PR DESCRIPTION
- Fixes movement allowed in idle mode and change scaling to previous values.
- Added example config for OM_MOWER_GAMEPAD.
- Changed to xesc_msgs from vesc_msgs
