### PR TITLE
Stop ignoring OM_MOWING_MOTOR_TEMP_* envvars

### DIFF
--- a/src/open_mower/launch/open_mower.launch
+++ b/src/open_mower/launch/open_mower.launch
@@ -20,6 +20,8 @@
         <param name="mow_angle_offset" value="$(optenv OM_MOWING_ANGLE_OFFSET 0)"/>
         <param name="mow_angle_offset_is_absolute" value="$(optenv OM_MOWING_ANGLE_OFFSET_IS_ABSOLUTE False)"/>
         <param name="battery_full_voltage" value="$(env OM_BATTERY_FULL_VOLTAGE)"/>
+        <param name="motor_hot_temperature" value="$(env OM_MOWING_MOTOR_TEMP_HIGH)"/>
+        <param name="motor_cold_temperature" value="$(env OM_MOWING_MOTOR_TEMP_LOW)"/>
     </node>
     <node pkg="slic3r_coverage_planner" type="slic3r_coverage_planner" name="slic3r_coverage_planner" output="screen"/>
 


### PR DESCRIPTION
Seem to have been missed when the env vars were originally introduced in 0b2d30a7f3716d0b77b013a443dbf815ca641c82