### PR TITLE
Disable collision detection in docking FTC planner

### DIFF
--- a/src/open_mower/params/docking_ftc_local_planner.yaml
+++ b/src/open_mower/params/docking_ftc_local_planner.yaml
@@ -1,5 +1,6 @@
 DockingFTCPlanner:
   acceleration: 1.0
+  check_obstacles: false
   debug_pid: false
   forward_only: false
   goal_timeout: 20.0


### PR DESCRIPTION
Collision detection must be disabled for docking FTC planner as the dock may not be within a mowing/nav area.