### PR TITLE
Randomize mower-motor direction

### DIFF
--- a/src/mower_comms/src/mower_comms.cpp
+++ b/src/mower_comms/src/mower_comms.cpp
@@ -235,7 +235,7 @@ void publishActuatorsTimerTask(const ros::TimerEvent &timer_event) {
 
 bool setMowEnabled(mower_msgs::MowerControlSrvRequest &req, mower_msgs::MowerControlSrvResponse &res) {
     if (req.mow_enabled && !is_emergency()) {
-        speed_mow = (random() & 2) - 1; // Randomize direction (+1|-1)
+        speed_mow = req.mow_direction ? 1 : -1;
     } else {
         speed_mow = 0;
     }

--- a/src/mower_comms/src/mower_comms.cpp
+++ b/src/mower_comms/src/mower_comms.cpp
@@ -235,7 +235,7 @@ void publishActuatorsTimerTask(const ros::TimerEvent &timer_event) {
 
 bool setMowEnabled(mower_msgs::MowerControlSrvRequest &req, mower_msgs::MowerControlSrvResponse &res) {
     if (req.mow_enabled && !is_emergency()) {
-        speed_mow = 1;
+        speed_mow = (random() & 2) - 1; // Randomize direction (+1|-1)
     } else {
         speed_mow = 0;
     }

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -244,13 +244,13 @@ bool setMowerEnabled(bool enabled)
         mower_msgs::MowerControlSrv mow_srv;
         mow_srv.request.mow_enabled = enabled;
         mow_srv.request.mow_direction = started.sec & 0x1; // Randomize mower direction on second
-        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << mow_srv.request.mow_direction << ") call");
+        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << static_cast<unsigned>(mow_srv.request.mow_direction) << ") call");
 
         ros::Rate retry_delay(1);
         bool success = false;
         for(int i = 0; i < 10; i++) {
             if(mowClient.call(mow_srv)) {
-                ROS_INFO_STREAM("successfully set mower enabled to " << enabled << " (direction " << mow_srv.request.mow_direction << ")");
+                ROS_INFO_STREAM("successfully set mower enabled to " << enabled << " (direction " << static_cast<unsigned>(mow_srv.request.mow_direction) << ")");
                     success = true;
                 break;
             }
@@ -262,7 +262,7 @@ bool setMowerEnabled(bool enabled)
             ROS_ERROR_STREAM("Error setting mower enabled. THIS SHOULD NEVER HAPPEN");
         }
 
-        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << mow_srv.request.mow_direction << ") call completed within " << (ros::Time::now() - started).toSec() << "s");
+        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << static_cast<unsigned>(mow_srv.request.mow_direction) << ") call completed within " << (ros::Time::now() - started).toSec() << "s");
         mowerEnabled = enabled;
     }
 

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -240,17 +240,18 @@ bool setMowerEnabled(bool enabled)
     // status change ?
     if (mowerEnabled != enabled)
     {
+        ros::Time started = ros::Time::now();
         mower_msgs::MowerControlSrv mow_srv;
         mow_srv.request.mow_enabled = enabled;
-        ros::Time started = ros::Time::now();
-        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ") call");
+        mow_srv.request.mow_direction = started.sec & 0x1; // Randomize mower direction on second
+        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << mow_srv.request.mow_direction << ") call");
 
         ros::Rate retry_delay(1);
         bool success = false;
         for(int i = 0; i < 10; i++) {
             if(mowClient.call(mow_srv)) {
-                ROS_INFO_STREAM("successfully set mower enabled to " << enabled);
-                success = true;
+                ROS_INFO_STREAM("successfully set mower enabled to " << enabled << " (direction " << mow_srv.request.mow_direction << ")");
+                    success = true;
                 break;
             }
             ROS_ERROR_STREAM("Error setting mower enabled to " << enabled << ". Retrying.");
@@ -261,7 +262,7 @@ bool setMowerEnabled(bool enabled)
             ROS_ERROR_STREAM("Error setting mower enabled. THIS SHOULD NEVER HAPPEN");
         }
 
-        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ") call completed within " << (ros::Time::now()-started).toSec() << "s");
+        ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled(" << enabled << ", " << mow_srv.request.mow_direction << ") call completed within " << (ros::Time::now() - started).toSec() << "s");
         mowerEnabled = enabled;
     }
 

--- a/src/mower_msgs/srv/MowerControlSrv.srv
+++ b/src/mower_msgs/srv/MowerControlSrv.srv
@@ -1,2 +1,3 @@
 uint8 mow_enabled
+uint8 mow_direction
 ---


### PR DESCRIPTION
Let mower-motor spin CW or CCW by random, for usage of both blade sides