### PR TITLE
Save/restore mowing progress across service/container restarts

### DIFF
--- a/src/mower_logic/CMakeLists.txt
+++ b/src/mower_logic/CMakeLists.txt
@@ -14,17 +14,20 @@ find_package(catkin REQUIRED COMPONENTS
   mower_map
   mower_msgs
   nav_msgs
+  rosbag
   roscpp
   slic3r_coverage_planner
   tf2
   tf2_geometry_msgs
   tf2_ros
-        sensor_msgs
-        robot_localization
-        xbot_msgs
-        xbot_positioning
+  sensor_msgs
+  robot_localization
+  xbot_msgs
+  xbot_positioning
 )
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CRYPTOPP REQUIRED libcrypto++)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -60,11 +63,10 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  CheckPoint.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -81,10 +83,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
+generate_messages(
 #   DEPENDENCIES
 #   mbf_msgs#   mower_msgs#   nav_msgs#   tf2_geometry_msgs
-# )
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -131,6 +133,7 @@ catkin_package(
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
+  ${CRYPTOPP_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -178,7 +181,7 @@ add_executable(mower_logic
         src/mower_logic/behaviors/AreaRecordingBehavior.cpp
         )
 add_dependencies(mower_logic ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(mower_logic ${catkin_LIBRARIES})
+target_link_libraries(mower_logic ${catkin_LIBRARIES} ${CRYPTOPP_LIBRARIES})
 
 add_executable(mower_odometry src/mower_odometry/mower_odometry.cpp)
 add_dependencies(mower_odometry ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -17,7 +17,6 @@ gen.add("mow_angle_increment", double_t, 0, "Mowing angle automatic increment. W
 gen.add("tool_width", double_t, 0, "Width of the mower", 0.14, 0.1, 2)
 gen.add("enable_mower", bool_t, 0, "True to enable mow motor", False)
 gen.add("manual_pause_mowing", bool_t, 0, "True to disable mowing automatically", False)
-gen.add("current_area", int_t, 0, "Current Mow Area", 0, 0, 99)
 gen.add("battery_empty_voltage", double_t, 0, "Voltage to return to docking station", 25.0, 20.0, 32.0)
 gen.add("battery_full_voltage", double_t, 0, "Voltage to start mowing again", 29.0, 20.0, 32.0)
 gen.add("motor_hot_temperature", double_t, 0, "Motor temperature to pause mowing", 70.0, 20.0, 150.0)

--- a/src/mower_logic/msg/CheckPoint.msg
+++ b/src/mower_logic/msg/CheckPoint.msg
@@ -1,0 +1,5 @@
+int32 currentMowingPath
+int32 currentMowingArea
+int32 currentMowingPathIndex
+string currentMowingPlanDigest
+float32 currentMowingAngleIncrementSum

--- a/src/mower_logic/package.xml
+++ b/src/mower_logic/package.xml
@@ -24,6 +24,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>xbot_msgs</build_depend>
+  <build_depend>crypto++</build_depend>
   <depend>xbot_positioning</depend>
   <build_export_depend>dynamic_reconfigure</build_export_depend>
   <build_export_depend>ftc_local_planner</build_export_depend>

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -515,7 +515,7 @@ bool MowingBehavior::execute_mowing_plan() {
                     // if something else -> Recovery Behaviour ?
 
                     // currentMowingPathIndex might be 0 if we never consumed one of the points, we advance at least 1 point
-                    currentMowingPathIndex++;
+                    if( currentMowingPathIndex == 0) currentMowingPathIndex++;
                     ROS_INFO_STREAM("MowingBehavior: (MOW) PAUSED due to MBF Error at " << currentMowingPathIndex);
                     this->setPause();
                     update_actions();

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -403,8 +403,7 @@ bool MowingBehavior::execute_mowing_plan() {
                         // Unable to reach the start of the mow path (we tried multiple attempts for the same point, and we skipped points which also didnt work, time to give up) 
                         ROS_ERROR_STREAM("MowingBehavior: (FIRST POINT) Max retries reached, we are unable to reach any of the first points - aborting at index: "
                             << currentMowingPathIndex << " path: " << currentMowingPath << " area: " << currentMowingArea );
-                        currentMowingPath++;
-                        currentMowingPathIndex = 0;
+                        this->abort();
                     }
                 }
                 continue;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
@@ -40,6 +40,13 @@ private:
     bool mowerEnabled = false;
     std::vector<slic3r_coverage_planner::Path> currentMowingPaths;
 
+    ros::Time last_checkpoint;
+    int currentMowingPath;
+    int currentMowingArea;
+    int currentMowingPathIndex;
+    std::string currentMowingPlanDigest;
+    double currentMowingAngleIncrementSum;
+
 
 public:
     MowingBehavior();
@@ -77,6 +84,10 @@ public:
     void handle_action(std::string action) override;
 
     void update_actions();
+
+    void checkpoint();
+
+    bool restore_checkpoint();
 };
 
 


### PR DESCRIPTION
Records the current plan progress in a bag file and restores on restart if exactly the same plan is being mowed.

A digest of all of the poses in the plan is used to determine if the plan is identical. This should work regardless of why the plan changed e.g if any params that affect slicing change, or if the slicer logic changes.