### PR TITLE
Dock when rain detected and only dock when mowing

### DIFF
--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -30,5 +30,6 @@ gen.add("add_fake_obstacle", bool_t, 0, "True to add a fake obstacle to hopefull
 gen.add("ignore_gps_errors", bool_t, 0, "True to ignore gps errors. USE ONLY FOR SIMULATION!", False)
 gen.add("max_first_point_attempts", int_t, 0, "Maximum attempts to reach the first point of the mow path before trimming", 3, 1, 10)
 gen.add("max_first_point_trim_attempts", int_t, 0, "After <max_first_point_attempts> we start to trim the path beginning this often", 3, 1, 10)
+gen.add("dock_when_raining", bool_t, 0, "True to dock when rain is detected", False)
 
 exit(gen.generate("mower_logic", "mower_logic", "MowerLogic"))

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -31,6 +31,7 @@ extern dynamic_reconfigure::Server<mower_logic::MowerLogicConfig> *reconfigServe
 extern ros::ServiceClient mapClient;
 extern ros::ServiceClient dockingPointClient;
 
+extern bool rain;
 
 IdleBehavior IdleBehavior::INSTANCE;
 
@@ -72,7 +73,7 @@ Behavior *IdleBehavior::execute() {
         const bool automatic_mode = last_config.automatic_mode == eAutoMode::AUTO;
         const bool active_semiautomatic_task = last_config.automatic_mode == eAutoMode::SEMIAUTO && shared_state->active_semiautomatic_task == true;
         const bool mower_ready = last_status.v_battery > last_config.battery_full_voltage && last_status.mow_esc_status.temperature_motor < last_config.motor_cold_temperature &&
-                !last_config.manual_pause_mowing;
+                !last_config.manual_pause_mowing && !(last_config.dock_when_raining && rain);
 
         if (manual_start_mowing || ((automatic_mode || active_semiautomatic_task) && mower_ready)) {
             // set the robot's position to the dock if we're actually docked

--- a/src/open_mower/config/mower_config.sh.example
+++ b/src/open_mower/config/mower_config.sh.example
@@ -127,6 +127,9 @@ export OM_AUTOMATIC_MODE=0
 
 export OM_OUTLINE_OFFSET=0.05
 
+# Return to dock when rain detected and pause automatic start until rain sensor is dry
+export OM_DOCK_WHEN_RAINING=False
+
 ################################
 ##    External MQTT Broker    ##
 ################################

--- a/src/open_mower/launch/open_mower.launch
+++ b/src/open_mower/launch/open_mower.launch
@@ -26,6 +26,7 @@
         <param name="motor_cold_temperature" value="$(env OM_MOWING_MOTOR_TEMP_LOW)"/>
         <param name="gps_wait_time" value="$(optenv OM_GPS_WAIT_TIME_SEC 10.0)"/>
         <param name="gps_timeout" value="$(optenv OM_GPS_TIMEOUT_SEC 10.0)"/>
+        <param name="dock_when_raining" value="$(optenv OM_DOCK_WHEN_RAINING False)"/>
     </node>
     <node pkg="slic3r_coverage_planner" type="slic3r_coverage_planner" name="slic3r_coverage_planner" output="screen"/>
 


### PR DESCRIPTION
Log the docking reason.
Only dock when mowing, otherwise can abort DockingBehavior.

Add option to dock when rain is detected.
Initial logic is very basic, just dock when rain detected and if automatic mode is set will stay docked until rain is no longer detected.