### PR TITLE
mower_map needs xbot_msgs in CMakeLists.txt

### DIFF
--- a/src/mower_map/CMakeLists.txt
+++ b/src/mower_map/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED
         grid_map_filters
         grid_map_cv
         rosbag
+        xbot_msgs
         )
 
 ## System dependencies are found with CMake's conventions


### PR DESCRIPTION
Otherwise get this error when running catkin build:
```
/home/lucasw/ros/ros1_stackexchange/src/open_mower_ros/src/mower_map/src/mower_map_service.cpp:51:10: fatal error: xbot_msgs/Map.h: No such file or directory
   51 | #include "xbot_msgs/Map.h"
      |          ^~~~~~~~~~~~~~~~~
```