### PR TITLE
HL->LL config packet with "DFP is 5V" implementation

### DIFF
--- a/src/mower_comms/src/ll_datatypes.h
+++ b/src/mower_comms/src/ll_datatypes.h
@@ -25,7 +25,7 @@
 #define PACKET_ID_LL_UI_EVENT 3
 #define PACKET_ID_LL_HEARTBEAT 0x42
 #define PACKET_ID_LL_HIGH_LEVEL_STATE 0x43
-
+#define PACKET_ID_LL_HIGH_LEVEL_CONFIG 0x44
 
 #pragma pack(push, 1)
 struct ll_status {
@@ -57,6 +57,7 @@ struct ll_status {
     // Charge current
     float charging_current;
     uint8_t batt_percentage;
+    uint8_t volume; // Volume (0-100%) feedback (if directly changed via CoverUI)
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)
@@ -105,6 +106,18 @@ struct ll_high_level_state {
     uint8_t type;
     uint8_t current_mode; // see HighLevelMode
     uint8_t gps_quality;   // GPS quality in percent (0-100)
+    uint16_t crc;
+} __attribute__((packed));
+#pragma pack(pop)
+
+#define LL_HIGH_LEVEL_CONFIG_BIT_DFPIS5V 0b1 << 0           // Enable full sound via mower_config env var "OM_DFP_IS_5V"
+#define LL_HIGH_LEVEL_CONFIG_BIT_EMERGENCY_INVERSE 0b1 << 1 // Sample, for possible future usage, i.e. for SA-Type emergency
+
+#pragma pack(push, 1)
+struct ll_high_level_config
+{
+    uint8_t type;           // Type of this message. Has to be PACKET_ID_LL_HIGH_LEVEL_CONFIG
+    uint8_t config_bitmask; // See LL_HIGH_LEVEL_CONFIG_BIT_*
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)

--- a/src/mower_comms/src/ll_datatypes.h
+++ b/src/mower_comms/src/ll_datatypes.h
@@ -57,7 +57,8 @@ struct ll_status {
     // Charge current
     float charging_current;
     uint8_t batt_percentage;
-    uint8_t volume; // Volume (0-100%) feedback (if directly changed via CoverUI)
+    // FIXME: Implement comms_version handling before integrating volume feedback
+    // uint8_t volume; // Volume (0-100%) feedback (if directly changed via CoverUI)
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)
@@ -116,8 +117,11 @@ struct ll_high_level_state {
 #pragma pack(push, 1)
 struct ll_high_level_config
 {
-    uint8_t type;           // Type of this message. Has to be PACKET_ID_LL_HIGH_LEVEL_CONFIG
-    uint8_t config_bitmask; // See LL_HIGH_LEVEL_CONFIG_BIT_*
+    uint8_t type = PACKET_ID_LL_HIGH_LEVEL_CONFIG;
+    uint8_t comms_version = 1;  // Increasing comms version number for packet compatibility (n > 0)
+    uint8_t config_bitmask = 0; // See LL_HIGH_LEVEL_CONFIG_BIT_*
+    uint8_t spare1 = 0;         // Spare for future use
+    uint16_t spare2 = 0;        // Spare for future use
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)

--- a/src/mower_comms/src/ll_datatypes.h
+++ b/src/mower_comms/src/ll_datatypes.h
@@ -23,9 +23,10 @@
 #define PACKET_ID_LL_STATUS 1
 #define PACKET_ID_LL_IMU 2
 #define PACKET_ID_LL_UI_EVENT 3
+#define PACKET_ID_LL_HIGH_LEVEL_CONFIG_REQ 0x21 // ll_high_level_config and request config from receiver
+#define PACKET_ID_LL_HIGH_LEVEL_CONFIG_RSP 0x22 // ll_high_level_config response
 #define PACKET_ID_LL_HEARTBEAT 0x42
 #define PACKET_ID_LL_HIGH_LEVEL_STATE 0x43
-#define PACKET_ID_LL_HIGH_LEVEL_CONFIG 0x44
 
 #pragma pack(push, 1)
 struct ll_status {
@@ -57,8 +58,6 @@ struct ll_status {
     // Charge current
     float charging_current;
     uint8_t batt_percentage;
-    // FIXME: Implement comms_version handling before integrating volume feedback
-    // uint8_t volume; // Volume (0-100%) feedback (if directly changed via CoverUI)
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)
@@ -111,17 +110,21 @@ struct ll_high_level_state {
 } __attribute__((packed));
 #pragma pack(pop)
 
-#define LL_HIGH_LEVEL_CONFIG_BIT_DFPIS5V 0b1 << 0           // Enable full sound via mower_config env var "OM_DFP_IS_5V"
-#define LL_HIGH_LEVEL_CONFIG_BIT_EMERGENCY_INVERSE 0b1 << 1 // Sample, for possible future usage, i.e. for SA-Type emergency
+#define LL_HIGH_LEVEL_CONFIG_MAX_COMMS_VERSION 1           // Max. comms packet version supported by this open_mower_ros
+#define LL_HIGH_LEVEL_CONFIG_BIT_DFPIS5V 1 << 0            // Enable full sound via mower_config env var "OM_DFP_IS_5V"
+#define LL_HIGH_LEVEL_CONFIG_BIT_EMERGENCY_INVERSE 1 << 1  // Sample, for possible future usage, i.e. for SA-Type emergency
+
+typedef char iso639_1[2];  // Two char ISO 639-1 language code
 
 #pragma pack(push, 1)
-struct ll_high_level_config
-{
-    uint8_t type = PACKET_ID_LL_HIGH_LEVEL_CONFIG;
-    uint8_t comms_version = 1;  // Increasing comms version number for packet compatibility (n > 0)
-    uint8_t config_bitmask = 0; // See LL_HIGH_LEVEL_CONFIG_BIT_*
-    uint8_t spare1 = 0;         // Spare for future use
-    uint16_t spare2 = 0;        // Spare for future use
+struct ll_high_level_config {
+    uint8_t type = PACKET_ID_LL_HIGH_LEVEL_CONFIG_RSP;               // By default, respond only (for now)
+    uint8_t comms_version = LL_HIGH_LEVEL_CONFIG_MAX_COMMS_VERSION;  // Increasing comms packet-version number for packet compatibility (n > 0)
+    uint8_t config_bitmask = 0;                                      // See LL_HIGH_LEVEL_CONFIG_BIT_*
+    int8_t volume;                                                   // Volume (0-100%) feedback (if directly changed via CoverUI). -1 = don't change
+    iso639_1 language;                                               // ISO 639-1 (2-char) language code (en, de, ...)
+    uint16_t spare1 = 0;                                             // Spare for future use
+    uint16_t spare2 = 0;                                             // Spare for future use
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)

--- a/src/mower_comms/src/mower_comms.cpp
+++ b/src/mower_comms/src/mower_comms.cpp
@@ -38,6 +38,8 @@
 #include <xbot_msgs/WheelTick.h>
 #include "mower_msgs/HighLevelStatus.h"
 
+#include <bitset>
+
 ros::Publisher status_pub;
 ros::Publisher wheel_tick_pub;
 
@@ -245,9 +247,7 @@ void publishLowLevelConfig() {
     if (!serial_port.isOpen() || !allow_send)
         return;
 
-    struct ll_high_level_config config_pkt = {
-        .type = PACKET_ID_LL_HIGH_LEVEL_CONFIG,
-        .config_bitmask = 0};
+    struct ll_high_level_config config_pkt;
 
     if (dfp_is_5v)
         config_pkt.config_bitmask |= LL_HIGH_LEVEL_CONFIG_BIT_DFPIS5V;
@@ -264,7 +264,7 @@ void publishLowLevelConfig() {
 
     try
     {
-        ROS_INFO("Send config_bitmask = %#04x", config_pkt.config_bitmask);
+        ROS_INFO_STREAM("Send ll_high_level_config packet with comms_version=" << +config_pkt.comms_version << ", config_bitmask=0b" << std::bitset<8>(config_pkt.config_bitmask));
         serial_port.write(out_buf, encoded_size);
     }
     catch (std::exception &e)

--- a/src/open_mower/config/mower_config.sh.example
+++ b/src/open_mower/config/mower_config.sh.example
@@ -55,6 +55,14 @@ export OM_MOWER_GAMEPAD="xbox360"
 # Output will be stored in your $HOME
 # export OM_ENABLE_RECORDING_ALL=False
 
+# Full Sound Support - But read on carefully:
+# Up to (and inclusive) OM hardware version 0.13.x, DFPlayer's power supply is set by default to 3.3V.
+# This is done by solder jumper "JP1" whose board track is by default at 3.3V.
+# If you manually opened the 3.3V track and solder a bridge to 5V, then you can indicate it here to get full sound support.
+# DO NOT enable "OM_DFP_IS_5V=True" if you haven't changed it in real. You might risk your "Raspberry Pico"!
+# And even if the Pico isn't expensive, it's a torture to replace it.
+# export OM_DFP_IS_5V=False
+
 ################################
 ##        GPS Settings        ##
 ################################

--- a/src/open_mower/config/mower_config.sh.example
+++ b/src/open_mower/config/mower_config.sh.example
@@ -62,6 +62,17 @@ export OM_MOWER_GAMEPAD="xbox360"
 # DO NOT enable "OM_DFP_IS_5V=True" if you haven't changed it in real. You might risk your "Raspberry Pico"!
 # And even if the Pico isn't expensive, it's a torture to replace it.
 # export OM_DFP_IS_5V=False
+#
+# Language as ISO-639-1 code string (currently only used by sound).
+# Overwrite a previously configure language (i.e. changed by CoverUI)
+# Supported languages: en|de
+# export OM_LANGUAGE="en"
+#
+# Sound volume (%)
+# Supported values:
+# 0-100 = Set sound volume on OM start, ignoring previously set volume level (i.e. by CoverUI)
+#    -1 = Don't change a previusoly set volume level (i.e. by CoverUI)
+# export OM_VOLUME=-1
 
 ################################
 ##        GPS Settings        ##

--- a/src/open_mower/launch/include/_comms.launch
+++ b/src/open_mower/launch/include/_comms.launch
@@ -11,6 +11,7 @@
         <rosparam if="$(eval env('OM_MOWER')=='CUSTOM')" file="$(env HOME)/mower_params/comms_params.yaml"/>
         <param name="wheel_ticks_per_m" value="$(env OM_WHEEL_TICKS_PER_M)"/>
         <param name="wheel_distance_m" value="$(env OM_WHEEL_DISTANCE_M)"/>
+        <param name="dfp_is_5v" value="$(optenv OM_DFP_IS_5V False)"/>
     </node>
     
     <include file="$(find open_mower)/launch/include/_gps.launch" unless="$(optenv OM_NO_GPS False)">

--- a/src/open_mower/launch/include/_comms.launch
+++ b/src/open_mower/launch/include/_comms.launch
@@ -12,6 +12,8 @@
         <param name="wheel_ticks_per_m" value="$(env OM_WHEEL_TICKS_PER_M)"/>
         <param name="wheel_distance_m" value="$(env OM_WHEEL_DISTANCE_M)"/>
         <param name="dfp_is_5v" value="$(optenv OM_DFP_IS_5V False)"/>
+        <param name="language" value="$(optenv OM_LANGUAGE en)"/>
+        <param name="volume" value="$(optenv OM_VOLUME -1)"/>
     </node>
     
     <include file="$(find open_mower)/launch/include/_gps.launch" unless="$(optenv OM_NO_GPS False)">


### PR DESCRIPTION
Related to https://github.com/ClemensElflein/OpenMower/pull/80

This is how I would implement the ROS part about what we discusses here:
https://github.com/ClemensElflein/OpenMower/pull/80#issuecomment-1989047608

Where I'm undetermined is:
In this proposal I added volume feedback to ll_status struct which would make a LL FW update mandatory.
I added it there, to not create another new packet and because it's the right place for it as it's a "status" (even if unimportant)
As an alternative we could add another new packet like ll_highlevel_misc :-))