### PR TITLE
Do not abort current behaviour after emergency is cleared

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/Behavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/Behavior.h
@@ -84,17 +84,22 @@ public:
 
     void requestContinue()
     {
-        requested_continue_flag = true;
+        if (paused) {
+            requested_continue_flag = true;
+        }
     }
 
     void requestPause()
     {
-        requested_pause_flag = true;
+        if (!paused) {
+            requested_pause_flag = true;
+        }
     }
 
     void setPause()
     {
         paused = true;
+        requested_continue_flag = false;
     }
 
     void setContinue()

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -286,7 +286,6 @@ bool MowingBehavior::execute_mowing_plan() {
         if (paused)
         {   
             paused_time = ros::Time::now();
-            mowerEnabled = false;
             while (!this->hasGoodGPS()) // while no good GPS we wait
             {
                 ROS_INFO_STREAM("MowingBehavior: PAUSED (" << (ros::Time::now()-paused_time).toSec() << "s) (waiting for /odom)");
@@ -296,7 +295,6 @@ bool MowingBehavior::execute_mowing_plan() {
             ROS_INFO_STREAM("MowingBehavior: CONTINUING");
             this->setContinue();
             update_actions();
-            mowerEnabled = true;
         }
     
 

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -129,8 +129,8 @@ void MowingBehavior::update_actions() {
     }
 
     // pause / resume switch. other actions are always available
-    actions[0].enabled = !paused &&  !requested_pause_flag;
-    actions[1].enabled = paused && !requested_continue_flag;
+    actions[0].enabled = !(requested_pause_flag & pauseType::PAUSE_MANUAL);
+    actions[1].enabled = requested_pause_flag & pauseType::PAUSE_MANUAL;
 
     registerActions("mower_logic:mowing", actions);
 }
@@ -272,28 +272,43 @@ bool MowingBehavior::execute_mowing_plan() {
         ////////////////////////////////////////////////
         if (requested_pause_flag)
         {  // pause was requested
-            this->setPause();  // set paused=true
-            update_actions();
+            paused = true;
             mowerEnabled = false;
-            while (!requested_continue_flag) // while not asked to continue, we wait
+            u_int8_t last_requested_pause_flags = 0;
+            while (requested_pause_flag) // while emergency and/or manual pause not asked to continue, we wait
             {
-                ROS_INFO_STREAM("MowingBehavior: PAUSED (waiting for CONTINUE)");
+                if (last_requested_pause_flags != requested_pause_flag) {
+                    update_actions();
+                }
+                last_requested_pause_flags = requested_pause_flag;
+
+                std::string pause_reason = "";
+                if (requested_pause_flag & pauseType::PAUSE_EMERGENCY) {
+                    pause_reason += "on EMERGENCY";
+                    if (requested_pause_flag & pauseType::PAUSE_MANUAL) {
+                        pause_reason += " and ";
+                    }
+                }
+                if (requested_pause_flag & pauseType::PAUSE_MANUAL) {
+                    pause_reason += "waiting for CONTINUE";
+                }
+                ROS_INFO_STREAM_THROTTLE(30, "MowingBehavior: PAUSED (" << pause_reason << ")");
                 ros::Rate r(1.0);
                 r.sleep();
             }
-            // we will drop into paused, thus will also wait for /odom to be valid again
+            // we will drop into paused, thus will also wait for GPS to be valid again
         }
         if (paused)
         {   
             paused_time = ros::Time::now();
             while (!this->hasGoodGPS()) // while no good GPS we wait
             {
-                ROS_INFO_STREAM("MowingBehavior: PAUSED (" << (ros::Time::now()-paused_time).toSec() << "s) (waiting for /odom)");
+                ROS_INFO_STREAM("MowingBehavior: PAUSED (" << (ros::Time::now()-paused_time).toSec() << "s) (waiting for GPS)");
                 ros::Rate r(1.0);
                 r.sleep();
             }
             ROS_INFO_STREAM("MowingBehavior: CONTINUING");
-            this->setContinue();
+            paused = false;
             update_actions();
         }
     
@@ -383,7 +398,7 @@ bool MowingBehavior::execute_mowing_plan() {
                 if (first_point_attempt_counter < config.max_first_point_attempts)
                 {
                     ROS_WARN_STREAM("MowingBehavior: (FIRST POINT) - Attempt " << first_point_attempt_counter << " / " << config.max_first_point_attempts << " Making a little pause ...");
-                    this->setPause();
+                    paused = true;
                     update_actions();
                 }
                 else
@@ -398,7 +413,7 @@ bool MowingBehavior::execute_mowing_plan() {
                         currentMowingPathIndex++;
                         first_point_trim_counter++;
                         first_point_attempt_counter = 0; // give it another <config.max_first_point_attempts> attempts
-                        this->setPause();
+                        paused = true;
                         update_actions();
                     }
                     else
@@ -520,9 +535,11 @@ bool MowingBehavior::execute_mowing_plan() {
 
                     // currentMowingPathIndex might be 0 if we never consumed one of the points, we advance at least 1 point
                     if( currentMowingPathIndex == 0) currentMowingPathIndex++;
-                    ROS_INFO_STREAM("MowingBehavior: (MOW) PAUSED due to MBF Error at " << currentMowingPathIndex);
-                    this->setPause();
-                    update_actions();
+                    if (!requested_pause_flag) {
+                        ROS_INFO_STREAM("MowingBehavior: (MOW) PAUSED due to MBF Error at " << currentMowingPathIndex);
+                        paused = true;
+                        update_actions();
+                    }
                 }
             }
         }

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -341,13 +341,6 @@ void setEmergencyMode(bool emergency)
         ROS_ERROR_STREAM("Error setting emergency. THIS SHOULD NEVER HAPPEN");
     }
 
-    if(currentBehavior) {
-        if(emergency) {
-            currentBehavior->requestPause();
-        } else {
-            currentBehavior->requestContinue();
-        }
-    }
 }
 
 void updateUI(const ros::TimerEvent &timer_event) {
@@ -381,7 +374,6 @@ void checkSafety(const ros::TimerEvent &timer_event) {
     const auto status_time = getStatusTime();
     const auto last_good_gps = getLastGoodGPS();
 
-
     // call the mower
     setMowerEnabled(currentBehavior != nullptr && currentBehavior->mower_enabled());
 
@@ -389,12 +381,17 @@ void checkSafety(const ros::TimerEvent &timer_event) {
     high_level_status.is_charging = last_status.v_charge > 10.0;
 
     // send to idle if emergency and we're not recording
-    if(last_status.emergency) {
-        if(currentBehavior == &AreaRecordingBehavior::INSTANCE || currentBehavior == &IdleBehavior::INSTANCE) {
-            if(last_status.v_charge > 10.0) {
-                // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's safe since we won't start moving in this mode.
-                setEmergencyMode(false);
+    if (currentBehavior != nullptr) {
+        if(last_status.emergency) {
+            currentBehavior->requestPause();
+            if(currentBehavior == &AreaRecordingBehavior::INSTANCE || currentBehavior == &IdleBehavior::INSTANCE) {
+                if(last_status.v_charge > 10.0) {
+                    // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's safe since we won't start moving in this mode.
+                    setEmergencyMode(false);
+                }
             }
+        } else {
+            currentBehavior->requestContinue();
         }
     }
 

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -383,7 +383,7 @@ void checkSafety(const ros::TimerEvent &timer_event) {
     // send to idle if emergency and we're not recording
     if (currentBehavior != nullptr) {
         if(last_status.emergency) {
-            currentBehavior->requestPause();
+            currentBehavior->requestPause(pauseType::PAUSE_EMERGENCY);
             if(currentBehavior == &AreaRecordingBehavior::INSTANCE || currentBehavior == &IdleBehavior::INSTANCE) {
                 if(last_status.v_charge > 10.0) {
                     // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's safe since we won't start moving in this mode.
@@ -391,7 +391,7 @@ void checkSafety(const ros::TimerEvent &timer_event) {
                 }
             }
         } else {
-            currentBehavior->requestContinue();
+            currentBehavior->requestContinue(pauseType::PAUSE_EMERGENCY);
         }
     }
 

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -341,6 +341,13 @@ void setEmergencyMode(bool emergency)
         ROS_ERROR_STREAM("Error setting emergency. THIS SHOULD NEVER HAPPEN");
     }
 
+    if(currentBehavior) {
+        if(emergency) {
+            currentBehavior->requestPause();
+        } else {
+            currentBehavior->requestContinue();
+        }
+    }
 }
 
 void updateUI(const ros::TimerEvent &timer_event) {

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -224,11 +224,11 @@ bool setGPS(bool enabled) {
 }
 
 
-/// @brief If the BLADE Motor is not in the requested status (enabled),we call the 
+/// @brief If the BLADE Motor is not in the requested status (enabled),we call the
 ///        the mower_service/mow_enabled service to enable/disable. TODO: get feedback about spinup and delay if needed
-/// @param enabled 
-/// @return 
-bool setMowerEnabled(bool enabled) 
+/// @param enabled
+/// @return
+bool setMowerEnabled(bool enabled)
 {
     const auto last_config = getConfig();
 
@@ -236,7 +236,7 @@ bool setMowerEnabled(bool enabled)
         // ROS_INFO_STREAM("om_mower_logic: setMowerEnabled() - Mower should be enabled but is hard-disabled in the config.");
         enabled = false;
     }
-    
+
     // status change ?
     if (mowerEnabled != enabled)
     {
@@ -317,8 +317,8 @@ void stopBlade()
 
 
 /// @brief Stop BLADE motor and any movement
-/// @param emergency 
-void setEmergencyMode(bool emergency) 
+/// @param emergency
+void setEmergencyMode(bool emergency)
 {
     stopBlade();
     stopMoving();
@@ -365,7 +365,7 @@ bool isGpsGood() {
 }
 
 /// @brief Called every 0.5s, used to control BLADE motor via mower_enabled variable and stop any movement in case of /odom and /mower/status outages
-/// @param timer_event 
+/// @param timer_event
 void checkSafety(const ros::TimerEvent &timer_event) {
     const auto last_status = getStatus();
     const auto last_config = getConfig();
@@ -383,11 +383,11 @@ void checkSafety(const ros::TimerEvent &timer_event) {
 
     // send to idle if emergency and we're not recording
     if(last_status.emergency) {
-        if(currentBehavior != &AreaRecordingBehavior::INSTANCE && currentBehavior != &IdleBehavior::INSTANCE) {
-            abortExecution();
-        } else if(last_status.v_charge > 10.0) {
-            // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's safe since we won't start moving in this mode.
-            setEmergencyMode(false);
+        if(currentBehavior == &AreaRecordingBehavior::INSTANCE || currentBehavior == &IdleBehavior::INSTANCE) {
+            if(last_status.v_charge > 10.0) {
+                // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's safe since we won't start moving in this mode.
+                setEmergencyMode(false);
+            }
         }
     }
 
@@ -401,10 +401,10 @@ void checkSafety(const ros::TimerEvent &timer_event) {
         ROS_WARN_STREAM_THROTTLE(5, "om_mower_logic: EMERGENCY pose values stopped. dt was: " << (ros::Time::now() - pose_time));
         return;
     }
- 
+
     // check if status is current. if not, we have a problem since it contains wheel ticks and so on.
     // Since these should never drop out, we enter emergency instead of "only" stopping
-    if (ros::Time::now() - status_time > ros::Duration(3)) 
+    if (ros::Time::now() - status_time > ros::Duration(3))
     {
         setEmergencyMode(true);
         ROS_WARN_STREAM_THROTTLE(5, "om_mower_logic: EMERGENCY /mower/status values stopped. dt was: " << (ros::Time::now() - status_time));
@@ -505,7 +505,7 @@ bool highLevelCommand(mower_msgs::HighLevelControlSrvRequest &req, mower_msgs::H
             }
             break;
         case mower_msgs::HighLevelControlSrvRequest::COMMAND_S2:
-	        ROS_INFO_STREAM("COMMAND_S2"); 
+	        ROS_INFO_STREAM("COMMAND_S2");
             if(currentBehavior) {
                 currentBehavior->command_s2();
             }


### PR DESCRIPTION
Rebased @2m's PR https://github.com/ClemensElflein/open_mower_ros/pull/65 on latest main and added patch to pause/resume during emergency.

Briefly tested it with by triggering/clearing emergency and not noticed any obvious issues.
Also appears to resolve an issue where mower is enabled too early if gps drops/recovers before starting to mow

Fixes #52