### PR TITLE
No retry docking

### DIFF
--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -8,7 +8,7 @@ gen.add("automatic_mode", int_t, 0, "0 - Manual, 1 - Semiautomatic, 2 - Automati
 gen.add("undock_distance", double_t, 0, "Distance to drive back for undocking", 2, 0, 100)
 gen.add("docking_distance", double_t, 0, "Distance to drive forward during docking", 2, 0, 100)
 gen.add("docking_approach_distance", double_t, 0, "Distance to approach docking point", 1.5, 0, 5)
-gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 1, 10)
+gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 0, 10)
 gen.add("perimeter_signal",int_t, 0, "Which perimeter signal should be used? 0-None, positive number gives signal number and uses counterclockwise docking, negative numbers use clockwise docking", 0, -2, 2)
 gen.add("outline_count", int_t, 0, "Outline count to mow before filling", 3, 0, 255)
 gen.add("outline_overlap_count", int_t, 0, "Outlines to overlap with fill", 0, 0, 255)

--- a/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
@@ -203,8 +203,8 @@ Behavior *DockingBehavior::execute() {
         return &IdleBehavior::INSTANCE;
     }
 
-    // Reset retryCount
-    reset();
+    // Reset retryCount here would cause an infinite loop
+    // reset();
 
     // Disable GPS
     inApproachMode = false;
@@ -225,8 +225,10 @@ Behavior *DockingBehavior::execute() {
         }
 
         ROS_ERROR("Giving up on docking");
-        return &IdleBehavior::INSTANCE;
     }
+
+    // Reset retryCount
+    reset();
 
     return &IdleBehavior::INSTANCE;
 }


### PR DESCRIPTION
My garden is so small, that the mower does not need to charge to complete the mowing area. So I decided to place the base station in an unreachable place and recorded a dummy docking location instead. Obviously docking will never succeed. So I created the possibility to configure no retries. In addition it turned out, that even one configured retry ended in an infinite loop.