### PR TITLE
Add configuration for GPS serial port device

### DIFF
--- a/src/open_mower/config/mower_config.sh.example
+++ b/src/open_mower/config/mower_config.sh.example
@@ -88,6 +88,9 @@ export OM_USE_RELATIVE_POSITION=False
 # GPS protocol. Use UBX for u-blox chipsets and NMEA for everything else
 export OM_GPS_PROTOCOL=UBX
 
+# If you connected the GPS module in a different way (e.g. via USB), you can set the device here.
+export OM_GPS_SERIAL_PORT="/dev/ttyAMA1"
+
 # If you use a different gps board you maybe want to set a different baudrate.
 export OM_GPS_BAUDRATE="921600"
 

--- a/src/open_mower/launch/include/_gps.launch
+++ b/src/open_mower/launch/include/_gps.launch
@@ -13,6 +13,7 @@
           respawn_delay="5">
         <rosparam if="$(eval env('OM_MOWER')=='CUSTOM')" file="$(env HOME)/mower_params/gps_params.yaml"/>
         <rosparam unless="$(eval env('OM_MOWER')=='CUSTOM')" file="$(find open_mower)/params/hardware_specific/$(env OM_MOWER)/comms_gps_params.yaml"/>
+        <param if="$(eval optenv('OM_GPS_SERIAL_PORT')!='')" name="serial_port" value="$(optenv OM_GPS_SERIAL_PORT)"/>
         <param if="$(eval optenv('OM_GPS_BAUDRATE')!='')" name="baudrate" value="$(optenv OM_GPS_BAUDRATE)"/>
         <param name="mode" value="absolute" unless="$(env OM_USE_RELATIVE_POSITION)"/>
         <param name="mode" value="relative" if="$(env OM_USE_RELATIVE_POSITION)"/>


### PR DESCRIPTION
I have connected my UM982 via USB, so I need to set the device to `/dev/ttyUSB0`.