### PR TITLE
Retry docking if the mower rolls off the charger

### DIFF
--- a/config/mower_config.schema.json
+++ b/config/mower_config.schema.json
@@ -226,6 +226,13 @@
           "description":"How many times to retry docking before giving up.",
           "x-environment-variable":"OM_DOCKING_RETRY_COUNT"
         },
+        "OM_DOCKING_REDOCK":{
+          "type":"boolean",
+          "title":"Docking retry count",
+          "default":false,
+          "description":"Whether to attempt redocking if the voltage is no longer detected after docking.",
+          "x-environment-variable":"OM_DOCKING_REDOCK"
+        },
         "OM_UNDOCK_DISTANCE":{
           "type":"number",
           "title":"Undock Distance",

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -120,6 +120,9 @@ export OM_DOCKING_EXTRA_TIME=0.0
 # How many times to retry docking before giving up.
 export OM_DOCKING_RETRY_COUNT=4
 
+# Whether to attempt redocking if the voltage is no longer detected after docking.
+export OM_DOCKING_REDOCK=False
+
 # The distance to drive for undocking. This needs to be large enough for the robot to have GPS reception
 export OM_UNDOCK_DISTANCE=2.0
 

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -10,6 +10,7 @@ gen.add("docking_distance", double_t, 0, "Distance to drive forward during docki
 gen.add("docking_approach_distance", double_t, 0, "Distance to approach docking point", 1.5, 0, 5)
 gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 0, 10)
 gen.add("docking_extra_time", double_t, 0, "Continue docking for extra time (s) to ensure good contact", 0, 0, 1.0)
+gen.add("docking_redock", bool_t, 0, "Whether to attempt redocking if the voltage is no longer detected after docking.", False)
 gen.add("perimeter_signal",int_t, 0, "Which perimeter signal should be used? 0-None, positive number gives signal number and uses counterclockwise docking, negative numbers use clockwise docking", 0, -2, 2)
 gen.add("outline_count", int_t, 0, "Outline count to mow before filling", 3, 0, 255)
 gen.add("outline_overlap_count", int_t, 0, "Outlines to overlap with fill", 0, 0, 255)

--- a/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
@@ -181,7 +181,7 @@ Behavior *DockingBehavior::execute() {
     if(getStatus().v_charge > 5.0) {
         ROS_INFO_STREAM("Already inside docking station, going directly to idle.");
         stopMoving();
-        return &IdleBehavior::INSTANCE;
+        return &IdleBehavior::DOCKED_INSTANCE;
     }
 
     while(!isGPSGood){
@@ -226,12 +226,15 @@ Behavior *DockingBehavior::execute() {
         }
 
         ROS_ERROR("Giving up on docking");
+        // Reset retryCount
+        reset();
+        return &IdleBehavior::INSTANCE;
     }
 
     // Reset retryCount
     reset();
 
-    return &IdleBehavior::INSTANCE;
+    return &IdleBehavior::DOCKED_INSTANCE;
 }
 
 void DockingBehavior::enter() {

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -99,7 +99,7 @@ Behavior *IdleBehavior::execute() {
             return &IdleBehavior::INSTANCE;
         }
 
-        if (stay_docked && last_status.v_charge < 5.0) {
+        if (last_config.docking_redock && stay_docked && last_status.v_charge < 5.0) {
             ROS_WARN("We docked but seem to have lost contact with the charger.  Undocking and trying again!");
             return &UndockingBehavior::RETRY_INSTANCE;
         }

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -33,7 +33,8 @@ extern ros::ServiceClient mapClient;
 extern ros::ServiceClient dockingPointClient;
 
 
-IdleBehavior IdleBehavior::INSTANCE;
+IdleBehavior IdleBehavior::INSTANCE(false);
+IdleBehavior IdleBehavior::DOCKED_INSTANCE(true);
 
 std::string IdleBehavior::state_name() {
     return "IDLE";
@@ -76,7 +77,7 @@ Behavior *IdleBehavior::execute() {
                 !last_config.manual_pause_mowing;
 
         if (manual_start_mowing || ((automatic_mode || active_semiautomatic_task) && mower_ready)) {
-            // set the robot's position to the dock if we're actually docked
+                        // set the robot's position to the dock if we're actually docked
             if(last_status.v_charge > 5.0) {
               if (PerimeterUndockingBehavior::configured(config))
                 return &PerimeterUndockingBehavior::INSTANCE;
@@ -96,6 +97,11 @@ Behavior *IdleBehavior::execute() {
         // This gets called if we need to refresh, e.g. on clearing maps
         if(aborted) {
             return &IdleBehavior::INSTANCE;
+        }
+
+        if (stay_docked && last_status.v_charge < 5.0) {
+            ROS_WARN("We docked but seem to have lost contact with the charger.  Undocking and trying again!");
+            return &UndockingBehavior::RETRY_INSTANCE;
         }
 
         r.sleep();
@@ -170,7 +176,9 @@ uint8_t IdleBehavior::get_state() {
 
 
 
-IdleBehavior::IdleBehavior() {
+IdleBehavior::IdleBehavior(bool stayDocked) {
+    this->stay_docked = stayDocked;
+
     xbot_msgs::ActionInfo start_mowing_action;
     start_mowing_action.action_id = "start_mowing";
     start_mowing_action.enabled = false;

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.h
@@ -27,14 +27,16 @@
 
 class IdleBehavior : public Behavior {
 private:
+    bool stay_docked = false;
     bool manual_start_mowing = false;
     bool start_area_recorder = false;
     std::vector<xbot_msgs::ActionInfo> actions;
 
 public:
-    IdleBehavior();
+    IdleBehavior(bool stayDocked);
 
     static IdleBehavior INSTANCE;
+    static IdleBehavior DOCKED_INSTANCE;
 
     std::string state_name() override;
 

--- a/src/open_mower/launch/open_mower.launch
+++ b/src/open_mower/launch/open_mower.launch
@@ -16,6 +16,7 @@
         <param name="docking_distance" value="$(env OM_DOCKING_DISTANCE)"/>
         <param name="docking_extra_time" value="$(optenv OM_DOCKING_EXTRA_TIME 0)"/>
         <param name="docking_retry_count" value="$(optenv OM_DOCKING_RETRY_COUNT 4)"/>
+        <param name="docking_redock" value="$(optenv OM_DOCKING_REDOCK False)"/>
         <param name="undock_distance" value="$(env OM_UNDOCK_DISTANCE)"/>
         <param name="perimeter_signal" value="$(optenv OM_PERIMETER_SIGNAL)"/>
         <param name="tool_width" value="$(env OM_TOOL_WIDTH)"/>


### PR DESCRIPTION
This adds a new boolean to the idle state that tracks whether the mower is on the dock. If the mower detects that it is on the dock and it is no longer charging, it undocks and tries to redock.

This only applies to the cases where the mower has docked itself. If you manually place the mower on the charger this behavior will not activate.