### PR TITLE
Do not rebuild map in clearNavPoint when nav point is not set

### DIFF
--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -601,9 +601,11 @@ bool setNavPoint(mower_map::SetNavPointSrvRequest &req, mower_map::SetNavPointSr
 bool clearNavPoint(mower_map::ClearNavPointSrvRequest &req, mower_map::ClearNavPointSrvResponse &res) {
     ROS_INFO_STREAM("Clearing Nav Point");
 
-    show_fake_obstacle = false;
+    if (show_fake_obstacle) {
+        show_fake_obstacle = false;
 
-    buildMap();
+        buildMap();
+    }
 
     return true;
 }


### PR DESCRIPTION
Credit to Pete_MI632 for spotting this - rebuilding map to clear a non-existent nav point adds a significant delay (depending on map size) so only do this when required
