### PR TITLE
Allow to change docking_retry_count via env variable

### DIFF
--- a/config/mower_config.schema.json
+++ b/config/mower_config.schema.json
@@ -219,6 +219,13 @@
           "description":"Extra time in [s] to continue docking after voltage detection. This can be useful to make good contact with the base station. Use carefully.",
           "x-environment-variable":"OM_DOCKING_EXTRA_TIME"
         },
+        "OM_DOCKING_RETRY_COUNT":{
+          "type":"number",
+          "title":"Docking retry count",
+          "default":4,
+          "description":"How many times to retry docking before giving up.",
+          "x-environment-variable":"OM_DOCKING_RETRY_COUNT"
+        },
         "OM_UNDOCK_DISTANCE":{
           "type":"number",
           "title":"Undock Distance",

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -117,6 +117,9 @@ export OM_DOCKING_DISTANCE=1.0
 # Extra time (s) to continue docking after detecting voltage
 export OM_DOCKING_EXTRA_TIME=0.0
 
+# How many times to retry docking before giving up.
+export OM_DOCKING_RETRY_COUNT=4
+
 # The distance to drive for undocking. This needs to be large enough for the robot to have GPS reception
 export OM_UNDOCK_DISTANCE=2.0
 

--- a/src/open_mower/launch/open_mower.launch
+++ b/src/open_mower/launch/open_mower.launch
@@ -15,6 +15,7 @@
         <param name="automatic_mode" value="$(optenv OM_AUTOMATIC_MODE 0)"/>
         <param name="docking_distance" value="$(env OM_DOCKING_DISTANCE)"/>
         <param name="docking_extra_time" value="$(optenv OM_DOCKING_EXTRA_TIME 0)"/>
+        <param name="docking_retry_count" value="$(optenv OM_DOCKING_RETRY_COUNT 4)"/>
         <param name="undock_distance" value="$(env OM_UNDOCK_DISTANCE)"/>
         <param name="perimeter_signal" value="$(optenv OM_PERIMETER_SIGNAL)"/>
         <param name="tool_width" value="$(env OM_TOOL_WIDTH)"/>


### PR DESCRIPTION
I would like to increase how may docking attempts does the bot make, for that I would need to expose env variable.

cc @ClemensElflein 