### PR TITLE
Simulation: Set stamp for fake `mower/status`

### DIFF
--- a/src/mower_simulation/src/mower_simulation.cpp
+++ b/src/mower_simulation/src/mower_simulation.cpp
@@ -103,6 +103,7 @@ void publishStatus(const ros::TimerEvent &timer_event) {
         cmd_vel_pub.publish(last_cmd_vel);
     }
 
+    fake_mow_status.stamp = ros::Time::now();
     fake_mow_status.mow_esc_status.temperature_motor = config.temperature_mower;
     fake_mow_status.mow_esc_status.status = mower_msgs::ESCStatus::ESC_STATUS_OK;
     if (config.mower_error) {


### PR DESCRIPTION
Otherwise the timestamp is always zero, so all the updates are discarded in the monitoring node:
https://github.com/ClemensElflein/open_mower_ros/blob/a71af5ac17547d4a93d30484779fd2606ab3bcd1/src/mower_logic/src/monitoring/monitoring.cpp#L71-L74

Due to that, battery voltage et al. are shown as 0 in the web app.