### PR TITLE
Disable formatter in `src/lib/*`

### DIFF
--- a/src/lib/.clang-format
+++ b/src/lib/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
Otherwise VS Code reformats the whole file while working on submodules (if "Format on save" is activated). The submodules aren't prepared for this yet (no "format all files" commit) and should include their own definitions anyway, especially since they could be third-party with different ideas of code style.

The solution was taken from https://stackoverflow.com/a/57272592/25601664

I also tried creating a `.clang-format-ignore` file with content `src/lib/*`, but couldn't get it working.