### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
@@ -475,8 +475,9 @@ bool AreaRecordingBehavior::getDockingPosition(geometry_msgs::Pose &pos) {
 
     pos.position = odom_ptr->pose.pose.position;
 
+    tf2::Quaternion docking_orientation;
     double yaw = atan2(pos.position.y - first_docking_pos.position.y, pos.position.x - first_docking_pos.position.x);
-    tf2::Quaternion docking_orientation(0.0, 0.0, yaw);
+    docking_orientation.setRPY(0.0, 0.0, yaw);
     pos.orientation = tf2::toMsg(docking_orientation);
 
     update_actions();


### PR DESCRIPTION
Compiling mower_logic showed a warning about that constructor being deprecated. It would either call `setEuler()` or `setRPY()`. Testing in the simulator, `setRPY(0.0, 0.0, yaw)` seems to record the docking orientation fine, while `setEuler(yaw, 0.0, 0.0)` produced crap. That fits to the fact that I saw various `getRPY()` calls in the code base. But another pair of eyes would definitely help.