### PR TITLE
Allow users to configure retry counts above 10

### DIFF
--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -8,7 +8,7 @@ gen.add("automatic_mode", int_t, 0, "0 - Manual, 1 - Semiautomatic, 2 - Automati
 gen.add("undock_distance", double_t, 0, "Distance to drive back for undocking", 2, 0, 100)
 gen.add("docking_distance", double_t, 0, "Distance to drive forward during docking", 2, 0, 100)
 gen.add("docking_approach_distance", double_t, 0, "Distance to approach docking point", 1.5, 0, 5)
-gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 0, 10)
+gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 0, 50)
 gen.add("docking_extra_time", double_t, 0, "Continue docking for extra time (s) to ensure good contact", 0, 0, 1.0)
 gen.add("docking_redock", bool_t, 0, "Whether to attempt redocking if the voltage is no longer detected after docking.", False)
 gen.add("perimeter_signal",int_t, 0, "Which perimeter signal should be used? 0-None, positive number gives signal number and uses counterclockwise docking, negative numbers use clockwise docking", 0, -2, 2)


### PR DESCRIPTION
This will not change the default retry count, but allow users to configure more retries.

(Unfortunately 10 retries is not always enough for my mower to return home and dock successfully)