### PR TITLE
Add Backward/Forward recovery behavior

### DIFF
--- a/src/open_mower/params/move_base_flex.yaml
+++ b/src/open_mower/params/move_base_flex.yaml
@@ -8,12 +8,18 @@ controllers:
   - name: DockingFTCPlanner
     type: ftc_local_planner/FTCPlanner
 
+recovery_behaviors:
+  - name: BackwardForwardRecovery
+    type: ftc_local_planner/BackwardForwardRecovery
 
 controller_frequency: 1.0
 controller_patience: 30.0
 
 planner_frequency: 1.0
 planner_patience: 5.0
+
+recovery_enabled: true
+recovery_patience: 7.0
 
 oscillation_timeout: 10.0
 oscillation_distance: 0.2


### PR DESCRIPTION
This plugin will attempt to move directly backwards to regain traction, and if that fails, try to move directly forwards.  It will attempt to stop if it would collide with an object or leave the costmap.

This recovery behavior is set up using move_base_flex's plugin system,  so it will trigger when the planner fails.
    
I have been testing this behavior for the last year on my mower and it works very will in extremely challenging situations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automated recovery behavior with backward/forward recovery to improve resilience during navigation interruptions.
  * Recovery is now active by default with a configured patience period (7.0s) to allow controlled retry before escalation.
  * No changes to controller/planner frequencies; existing motion tuning remains intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->