### PR TITLE
Switch move_base_flex to post-Hydro params format to improve reliability

### DIFF
--- a/src/open_mower/params/costmap_common_params.yaml
+++ b/src/open_mower/params/costmap_common_params.yaml
@@ -1,6 +1,20 @@
-obstacle_range: 3.0
-raytrace_range: 4.0
 #footprint: [[x0, y0], [x1, y1], ... [xn, yn]]
 robot_radius: 0.0
 
-max_obstacle_height: 1.0
+global_frame: map
+robot_base_frame: base_link
+
+plugins:
+- name: static_layer
+  type: costmap_2d::StaticLayer
+- name: obstacle_layer
+  type: costmap_2d::ObstacleLayer
+- name: inflation_layer
+  type: costmap_2d::InflationLayer
+
+static_layer:
+  map_topic: mower_map_service/map
+obstacle_layer:
+  max_obstacle_height: 1.0
+  obstacle_range: 3.0
+  raytrace_range: 4.0

--- a/src/open_mower/params/global_costmap_params.yaml
+++ b/src/open_mower/params/global_costmap_params.yaml
@@ -1,10 +1,7 @@
 global_costmap:
-  inflation_radius: 1.0
-  global_frame: map
-  robot_base_frame: base_link
   update_frequency: 1.0
   publish_frequency: 1.0
-  static_map: true
   rolling_window: false
   resolution: 0.10
-  map_topic: mower_map_service/map
+  inflation_layer:
+    inflation_radius: 1.0

--- a/src/open_mower/params/local_costmap_params.yaml
+++ b/src/open_mower/params/local_costmap_params.yaml
@@ -1,12 +1,9 @@
 local_costmap:
-  inflation_radius: 0.0
-  global_frame: map
-  robot_base_frame: base_link
   update_frequency: 5.0
   publish_frequency: 2.0
   rolling_window: true
   width: 1.5
   height: 1.5
   resolution: 0.15
-  static_map: true
-  map_topic: mower_map_service/map
+  inflation_layer:
+    inflation_radius: 0.0


### PR DESCRIPTION
I was seeing flakiness in move_base_flex that seemed to be due to the automatic migration of parameters from the pre-Hydro to post-Hydro format (see http://wiki.ros.org/costmap_2d#costmap_2d.2Flayered.Pre-Hydro_Parameters).  It seems that sometimes the params would end up as a mixture of the two, causing the costmap to fail to be populated.

This PR just ports everything to the new post-Hydro format, so there is no automatic conversion that can go wrong.

I verified using `rosparam get /move_base_flex/global_costmap` that the only net effect on the parameters is that the `static_map: true` pre-Hydro parameter is gone, which does not matter since the post-Hydro static_layer parameters are all set correctly and enabled.