### PR TITLE
Add background-sound option

### DIFF
--- a/config/mower_config.schema.json
+++ b/config/mower_config.schema.json
@@ -635,6 +635,13 @@
           "description": "Sound volume (0-100 or -1). -1 means the volume is managed by the CoverUI.",
           "default": -1,
           "x-environment-variable": "OM_VOLUME"
+        },
+        "OM_BACKGROUND_SOUNDS": {
+          "type": "boolean",
+          "title": "Also play background sounds",
+          "description": "Enable if DFPlayer shall also play background-sounds (beside the informational advert sounds)",
+          "default": false,
+          "x-environment-variable": "OM_BACKGROUND_SOUNDS"
         }
       }
     },

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -85,8 +85,16 @@ export OM_MOWER_GAMEPAD="xbox360"
 # Sound volume (%)
 # Supported values:
 # 0-100 = Set sound volume on OM start, ignoring a previously set volume level (i.e. changed by CoverUI)
-#    -1 = Don't change a previously set volume level (i.e. changed by CoverUI)
+#    -1 = Don't change a previously set volume level
 # export OM_VOLUME=-1
+#
+# Background sounds
+# Beside some spoken informational advert sounds like "Waiting for RTK GPS" or "Heading back to docking station",
+# the current sound implementation might also play some funny background sounds like "I'm singing in the rain" once rain got detected.
+# But it will also play background sounds which might unsettle your wife or neighbor.
+# That's why it's configured false/off by default. If your wife or neightbor is heavy-duty, you can set it to "true" (on) here:
+# export OM_BACKGROUND_SOUNDS=False
+
 
 ################################
 ##        GPS Settings        ##

--- a/src/mower_comms/src/mower_comms.cpp
+++ b/src/mower_comms/src/mower_comms.cpp
@@ -643,6 +643,8 @@ int main(int argc, char **argv) {
       paramNh.param("/mower_logic/ignore_charging_current", false) ? OptionState::ON : OptionState::OFF;
   llhl_config.options.dfp_is_5v = paramNh.param("dfp_is_5v", false) ? OptionState::ON : OptionState::OFF;
   llhl_config.volume = paramNh.param("volume", -1);
+  llhl_config.options.background_sounds =
+      paramNh.param("background_sounds", false) ? OptionState::ON : OptionState::OFF;
   // ISO-639-1 (2 char) language code
   strncpy(llhl_config.language, paramNh.param<std::string>("language", "en").c_str(), 2);
 

--- a/src/open_mower/launch/include/_comms.launch
+++ b/src/open_mower/launch/include/_comms.launch
@@ -14,6 +14,7 @@
         <param name="dfp_is_5v" value="$(optenv OM_DFP_IS_5V False)"/>
         <param name="language" value="$(optenv OM_LANGUAGE en)"/>
         <param name="volume" value="$(optenv OM_VOLUME -1)"/>
+        <param name="background_sounds" value="$(optenv OM_BACKGROUND_SOUNDS False)"/>
     </node>
 
     <include file="$(find open_mower)/launch/include/_gps.launch" unless="$(optenv OM_NO_GPS False)">


### PR DESCRIPTION
OpenMower Improve-Sound PR https://github.com/ClemensElflein/OpenMower/pull/80 has background-sounds disabled by default.

Here's the option to enable it.