### PR TITLE
Disable FTC oscillation recovery by default

### DIFF
--- a/src/open_mower/params/docking_ftc_local_planner.yaml
+++ b/src/open_mower/params/docking_ftc_local_planner.yaml
@@ -1,6 +1,7 @@
 DockingFTCPlanner:
   acceleration: 1.0
   check_obstacles: false
+  oscillation_recovery: false
   debug_pid: false
   forward_only: false
   goal_timeout: 20.0

--- a/src/open_mower/params/ftc_local_planner.yaml
+++ b/src/open_mower/params/ftc_local_planner.yaml
@@ -1,6 +1,7 @@
 FTCPlanner:
   acceleration: 0.1
   check_obstacles: false
+  oscillation_recovery: false
   debug_pid: true
   forward_only: true
   goal_timeout: 20.0

--- a/src/open_mower/params/sim_ftc_local_planner.yaml
+++ b/src/open_mower/params/sim_ftc_local_planner.yaml
@@ -1,4 +1,6 @@
 FTCPlanner:
+  check_obstacles: false
+  oscillation_recovery: false
   acceleration: 2.0
   goal_timeout: 2.5
   kd_ang: 0.1


### PR DESCRIPTION
The default behaviour is to rotate on the spot to clear the costmap, but this causes the mower to collide with obstacles.

It only makes sense when lidar or ultrasonic sensors etc... are used to add obstacles to the costmap, so disable it by default.

Fixes #102