### PR TITLE
Smooth undock fix by Pete_MI632

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
@@ -57,6 +57,7 @@ Behavior *UndockingBehavior::execute() {
 
   const int straight_undock_point_count = 3;  // The FTC planner requires at least 3 points to work
   double incremental_distance = config.undock_distance / straight_undock_point_count;
+  path.poses.push_back(docking_pose_stamped_front);  // Start from current position
   for (int i = 0; i < straight_undock_point_count; i++) {
     docking_pose_stamped_front.pose.position.x -= cos(yaw) * incremental_distance;
     docking_pose_stamped_front.pose.position.y -= sin(yaw) * incremental_distance;


### PR DESCRIPTION
Since "angeled undocking" the mower does an initial harsh undocking step backwards.

@Pete_MI632 suggested a fix on [Discord](https://discord.com/channels/958476543846412329/961804411112394842/1304808196090757261).

Found the time to test today. Undock smoothly now :+1: 