### PR TITLE
IMU axis mapping for V2

### DIFF
--- a/src/mower_comms_v2/src/ImuServiceInterface.cpp
+++ b/src/mower_comms_v2/src/ImuServiceInterface.cpp
@@ -19,3 +19,50 @@ void ImuServiceInterface::OnAxesChanged(const double* new_value, uint32_t length
   imu_msg.angular_velocity.z = new_value[5];
   imu_publisher_.publish(imu_msg);
 }
+
+bool ImuServiceInterface::validateAxisConfig() {
+  if (axis_config_.size() != 6) {
+    ROS_ERROR_STREAM("Invalid IMU axis config length of '" << axis_config_ << "': " << axis_config_.size() << " != 6");
+    return false;
+  }
+
+  // Validate syntax: (+|-)(X|Y|Z)
+  for (size_t i = 0; i < 6; i += 2) {
+    if ((axis_config_[i] != '+' && axis_config_[i] != '-') ||
+        (axis_config_[i + 1] != 'X' && axis_config_[i + 1] != 'Y' && axis_config_[i + 1] != 'Z')) {
+      ROS_ERROR_STREAM("Invalid IMU axis config syntax ((+|-)(X|Y|Z)){3}: " << axis_config_);
+      return false;
+    }
+  }
+
+  // Validate on double axis use
+  if (axis_config_[1] == axis_config_[3] || axis_config_[1] == axis_config_[5] || axis_config_[3] == axis_config_[5]) {
+    ROS_ERROR_STREAM("Invalid IMU axis config '" << axis_config_ << "'! Double axis usage");
+    return false;
+  }
+
+  return true;
+}
+
+bool ImuServiceInterface::OnConfigurationRequested(uint16_t service_id) {
+  std::array<uint8_t, 3> axis_remap = {0, 1, 2};  // Default (YardForce mainboard) mapping: X->0, Y->1, Z->2
+  std::array<int8_t, 3> axis_sign = {1, -1, -1};  // Default (YardForce mainboard) signs
+
+  StartTransaction(true);
+
+  if (validateAxisConfig()) {
+    // Parse config string into axis_remap[] and axis_sign[]
+    for (int i = 0; i < 3; ++i) {
+      size_t pos = i * 2;                                  // Position within config string (0, 2, 4)
+      axis_sign[i] = (axis_config_[pos] == '+') ? 1 : -1;  // Assign sign
+      axis_remap[i] = axis_config_[pos + 1] - 'X';         // Assign mapping (via ASCII calc where 'X'->0, 'Y'->1, ...)
+    }
+  } else {
+    ROS_ERROR_STREAM("Invalid IMU axis config: " << axis_config_ << "! Use YardForce +X-Y-Z mapping.");
+  }
+  SetRegisterAxisRemap(axis_remap.data(), axis_remap.size());
+  SetRegisterAxisSign(axis_sign.data(), axis_sign.size());
+
+  CommitTransaction();
+  return true;
+}

--- a/src/mower_comms_v2/src/ImuServiceInterface.cpp
+++ b/src/mower_comms_v2/src/ImuServiceInterface.cpp
@@ -45,24 +45,28 @@ bool ImuServiceInterface::validateAxisConfig() {
 }
 
 bool ImuServiceInterface::OnConfigurationRequested(uint16_t service_id) {
-  std::array<uint8_t, 3> axis_remap = {0, 1, 2};  // Default (YardForce mainboard) mapping: X->0, Y->1, Z->2
-  std::array<int8_t, 3> axis_sign = {1, -1, -1};  // Default (YardForce mainboard) signs
+  std::array<int8_t, 3> axis_remap = {1, -2, -3};  // Default (YardForce mainboard) mapping: X=1, Y=-2, Z=-3
 
   StartTransaction(true);
 
   if (validateAxisConfig()) {
     // Parse config string into axis_remap[] and axis_sign[]
     for (int i = 0; i < 3; ++i) {
-      size_t pos = i * 2;                                  // Position within config string (0, 2, 4)
-      axis_sign[i] = (axis_config_[pos] == '+') ? 1 : -1;  // Assign sign
-      axis_remap[i] = axis_config_[pos + 1] - 'X';         // Assign mapping (via ASCII calc where 'X'->0, 'Y'->1, ...)
+      const size_t pos = i * 2;                                 // Position within config string (0, 2, 4)
+      const int8_t sign = (axis_config_[pos] == '+') ? 1 : -1;  // Axis sign
+
+      // ASCII-based axis calculation
+      const char axis = axis_config_[pos + 1];
+      const int8_t axis_num = static_cast<int8_t>((axis - 'X') + 1);  // X->1, Y->2, Z->3
+      assert(axis_num >= 1 && axis_num <= 3);
+
+      axis_remap[i] = sign * axis_num;
     }
   } else {
-    ROS_ERROR_STREAM("Invalid IMU axis config: " << axis_config_ << "! Use YardForce +X-Y-Z mapping.");
+    ROS_ERROR_STREAM("Invalid IMU axis config: " << axis_config_ << "! Using default YardForce +X-Y-Z mapping.");
   }
   SetRegisterAxisRemap(axis_remap.data(), axis_remap.size());
-  SetRegisterAxisSign(axis_sign.data(), axis_sign.size());
-
   CommitTransaction();
+
   return true;
 }

--- a/src/mower_comms_v2/src/ImuServiceInterface.h
+++ b/src/mower_comms_v2/src/ImuServiceInterface.h
@@ -12,17 +12,22 @@
 
 class ImuServiceInterface : public ImuServiceInterfaceBase {
  public:
-  ImuServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::Publisher& imu_publisher)
-      : ImuServiceInterfaceBase(service_id, ctx), imu_publisher_(imu_publisher) {
+  ImuServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::Publisher& imu_publisher,
+                      const std::string& axis_config)
+      : ImuServiceInterfaceBase(service_id, ctx), imu_publisher_(imu_publisher), axis_config_(axis_config) {
   }
+
+  bool OnConfigurationRequested(uint16_t service_id) override;
 
  protected:
   void OnAxesChanged(const double* new_value, uint32_t length) override;
 
  private:
   const ros::Publisher& imu_publisher_;
+  std::string axis_config_;
 
   sensor_msgs::Imu imu_msg{};
+  bool validateAxisConfig();
 };
 
 #endif  // IMUSERVICEINTERFACE_H

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -170,8 +170,11 @@ int main(int argc, char **argv) {
   mower_service->Start();
 
   // IMU service
+  std::string imu_axis_config;
+  paramNh.getParam("services/imu/axis_config", imu_axis_config);
+  ROS_INFO_STREAM("IMU axis config: " << imu_axis_config);
   sensor_imu_pub = n.advertise<sensor_msgs::Imu>("ll/imu/data_raw", 1);
-  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub);
+  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub, imu_axis_config);
   imu_service->Start();
 
   // Power service

--- a/src/open_mower/params/hardware_specific/Sabo/comms_v2_params.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/comms_v2_params.yaml
@@ -1,2 +1,0 @@
-gps_baudrate: 921600
-gps_protocol: "NMEA"

--- a/src/open_mower/params/hardware_specific/Sabo/comms_v2_params.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/comms_v2_params.yaml
@@ -1,0 +1,2 @@
+gps_baudrate: 921600
+gps_protocol: "NMEA"

--- a/src/open_mower/params/hardware_specific/Sabo/default_environment.sh
+++ b/src/open_mower/params/hardware_specific/Sabo/default_environment.sh
@@ -1,0 +1,11 @@
+# Set default GPS antenna offset
+export OM_ANTENNA_OFFSET_X=${OM_ANTENNA_OFFSET_X:-0.18}
+export OM_ANTENNA_OFFSET_Y=${OM_ANTENNA_OFFSET_Y:-0.0}
+
+# Set distance between wheels in m
+export OM_WHEEL_DISTANCE_M=${WHEEL_DISTANCE_M:-0.45}
+
+# Set default ticks/m
+export OM_WHEEL_TICKS_PER_M=${OM_WHEEL_TICKS_PER_M:-1195.0}
+
+export OM_V2=True

--- a/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
@@ -1,0 +1,11 @@
+mower_comms_v2:
+  services:
+    diff_drive:
+      wheel_distance_m: 0.45
+      ticks_per_m: 1195.0
+    imu:
+      axis_config: "+Z-X-Y"
+
+xbot_positioning:
+  antenna_offset_x: 0.18
+  antenna_offset_y: 0.0

--- a/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
@@ -4,8 +4,16 @@ mower_comms_v2:
       wheel_distance_m: 0.45
       ticks_per_m: 1195.0
     imu:
-      axis_config: "+Z-X-Y"
+      axis_config: "+Z+X+Y"
 
 xbot_positioning:
   antenna_offset_x: 0.18
   antenna_offset_y: 0.0
+
+mower_logic:
+  battery_empty_voltage: 21.0
+  battery_critical_voltage: 20.0
+  battery_full_voltage: 28.5
+  battery_critical_high_voltage: 29.4
+  charge_critical_high_voltage: 29.4
+  charge_critical_high_current: 3.9

--- a/src/open_mower/params/openmower_defaults_v2.yaml
+++ b/src/open_mower/params/openmower_defaults_v2.yaml
@@ -9,6 +9,8 @@ mower_comms_v2:
       baud_rate: 921600
       protocol: "UBX"
       datum_height: 0
+    imu:
+      axis_config: "+X-Y-Z"
 
 xbot_positioning:
   max_gps_accuracy: 0.2


### PR DESCRIPTION
This is how I would implement a flexible configurable IMU axis mapping.
Not yet tested, also SABO axis sign might be wrong because untested.

How it's implemented:

yaml config file get a new entry:
```
mower_comms_v2:
    imu:
      axis_config: "+Z-X-Y"
```

Syntax of axis_config is <axis sign +|-><physical IMU axis which shall be used for ROS axis X. One of X|Y|Z>...(same for ROS axis Y and Z)

ImuServiceInterface::OnConfigurationRequested() will parse the string into two new ImuService Registers:
```
"registers": [
    {
      "id": 0,
      "name": "AxisRemap",
      "type": "uint8_t[3]"
    },
    {
      "id": 1,
      "name": "AxisSign",
      "type": "int8_t[3]"
    }
  ]
```  

which in turn get directly used in firmware during assignment of Axes[].

Also related:
[FW PR](https://github.com/xtech/fw-openmower-v2/pull/8)
[IMU service registers PR](https://github.com/xtech/definitions-open-mower/pull/1)
