### PR TITLE
Improve OM_RAIN_DELAY_MINUTES documentation

### DIFF
--- a/config/mower_config.schema.json
+++ b/config/mower_config.schema.json
@@ -466,7 +466,7 @@
           "type": "number",
           "default": 30,
           "title": "Rain delay minutes",
-          "description": "How long to wait after rain to resume mowing when mode is \"Dock Until Dry\"",
+          "description": "How long to wait after rain to resume mowing when mode is \"Dock Until Dry\" (minimum value is 30)",
           "x-environment-variable": "OM_RAIN_DELAY_MINUTES"
         },
         "advanced": {

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -245,6 +245,7 @@ export OM_RAIN_MODE=0
 
 # Rain delay
 # How long to wait after rain to resume mowing when mode is "Dock Until Dry"
+# Minimum is 30
 export OM_RAIN_DELAY_MINUTES=30
 
 # Rain threshold (Stock-CoverUI limited parameter)


### PR DESCRIPTION
Just a  minor improvement, but it took me some time to figure out and maybe saves others some time (although a lower value is not reasonable for normal operation I tried to lower it for testing and was surprised that the value did not change).

Related info:
If the mower is in a garage the sensor dries although it is still raining. After the delay period the mower goes out. If it is still raining it goes into idle state at the end of undocking and not into docking again. It stays there for ever. This problem is fixed by PR179 (I think the solution is to always go into mowing state and handle rain detection there as always)