### PR TITLE
feat: Add configurable wait times for docking and undocking

### DIFF
--- a/config/mower_config.schema.json
+++ b/config/mower_config.schema.json
@@ -308,6 +308,20 @@
           "description": "Whether to attempt redocking if the voltage is no longer detected after docking.",
           "x-environment-variable": "OM_DOCKING_REDOCK"
         },
+        "OM_DOCKING_WAIT_TIME": {
+          "type": "number",
+          "title": "Wait before docking",
+          "default": 0,
+          "description": "Time to wait (s) at OM_DOCKING_APPROACH_DISTANCE before starting to dock.",
+          "x-environment-variable": "OM_DOCKING_WAIT_TIME"
+        },
+        "OM_UNDOCKING_WAIT_TIME": {
+          "type": "number",
+          "title": "Wait before undocking",
+          "default": 0,
+          "description": "Time to wait in dock (s) before before starting to undock",
+          "x-environment-variable": "OM_UNDOCKING_WAIT_TIME"
+        },
         "OM_UNDOCK_DISTANCE": {
           "type": "number",
           "title": "Undock Distance",

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -151,6 +151,9 @@ export OM_UNDOCK_DISTANCE=2.0
 #
 # If true will use a curved second stage undock move, if false will use a straight undock move.
 # export OM_UNDOCK_USE_CURVE=True
+#
+# Time to wait (s) before before starting to undock.
+export OM_UNDOCKING_WAIT_TIME=0.0
 
 # Docking:
 #
@@ -169,6 +172,9 @@ export OM_DOCKING_RETRY_COUNT=4
 #
 # Whether to attempt redocking if the voltage is no longer detected after docking.
 export OM_DOCKING_REDOCK=False
+#
+# Time to wait (s) at OM_DOCKING_APPROACH_DISTANCE before starting to dock.
+export OM_DOCKING_WAIT_TIME=0.0
 
 # Uncomment, if you want to use the perimeter sensor of your Mowgli-type mower
 # for docking. Set it to 1 or 2 dependig on the signal selected on the docking

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -15,6 +15,8 @@ gen.add("docking_approach_distance", double_t, 0, "Distance to approach docking 
 gen.add("docking_retry_count", int_t, 0, "How often should we retry docking", 4, 0, 50)
 gen.add("docking_extra_time", double_t, 0, "Continue docking for extra time (s) to ensure good contact", 0, 0, 1.0)
 gen.add("docking_redock", bool_t, 0, "Whether to attempt redocking if the voltage is no longer detected after docking.", False)
+gen.add("docking_waiting_time", double_t, 0, "Time to wait (s) before docking", 0, 0, 60)
+gen.add("undocking_waiting_time", double_t, 0, "Time to wait (s) before undocking", 0, 0, 60)
 gen.add("perimeter_signal",int_t, 0, "Which perimeter signal should be used? 0-None, positive number gives signal number and uses counterclockwise docking, negative numbers use clockwise docking", 0, -2, 2)
 gen.add("outline_count", int_t, 0, "Outline count to mow before filling", 3, 0, 255)
 gen.add("outline_overlap_count", int_t, 0, "Outlines to overlap with fill", 0, 0, 255)

--- a/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
@@ -61,6 +61,12 @@ bool DockingBehavior::approach_docking_point() {
 
     nav_msgs::Path path;
 
+    ros::Time start_wait_time = ros::Time::now();
+    ros::Rate loop_rate(100);
+    while (ros::ok() && (ros::Time::now() - start_wait_time) < ros::Duration(config.docking_waiting_time)) {
+      loop_rate.sleep();
+    }
+
     int dock_point_count = config.docking_approach_distance * 10.0;
     for (int i = 0; i <= dock_point_count; i++) {
       geometry_msgs::PoseStamped docking_pose_stamped_front = docking_pose_stamped;

--- a/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
@@ -54,6 +54,12 @@ Behavior *UndockingBehavior::execute() {
 
   nav_msgs::Path path;
 
+  ros::Time start_wait_time = ros::Time::now();
+  ros::Rate loop_rate(100);
+  while (ros::ok() && (ros::Time::now() - start_wait_time) < ros::Duration(config.undocking_waiting_time)) {
+    loop_rate.sleep();
+  }
+
   geometry_msgs::PoseStamped docking_pose_stamped_front;
   docking_pose_stamped_front.pose = pose.pose.pose;
   docking_pose_stamped_front.header = pose.header;

--- a/src/open_mower/launch/include/_params.launch
+++ b/src/open_mower/launch/include/_params.launch
@@ -128,6 +128,8 @@
         <param name="mower_logic/undock_angle" value="$(optenv OM_UNDOCK_ANGLE 0.0)"/>
         <param name="mower_logic/undock_fixed_angle" value="$(optenv OM_UNDOCK_FIXED_ANGLE True)"/>
         <param name="mower_logic/undock_use_curve" value="$(optenv OM_UNDOCK_USE_CURVE True)"/>
+        <param name="mower_logic/docking_waiting_time" value="$(optenv OM_DOCKING_WAIT_TIME 0.0)"/>
+        <param name="mower_logic/undocking_waiting_time" value="$(optenv OM_UNDOCKING_WAIT_TIME 0.0)"/>
         <param name="mower_logic/emergency_lift_period" value="$(optenv OM_EMERGENCY_LIFT_PERIOD -1)"/>
         <param name="mower_logic/emergency_tilt_period" value="$(optenv OM_EMERGENCY_TILT_PERIOD -1)"/>
         <param name="mower_logic/emergency_input_config" value="$(optenv OM_EMERGENCY_INPUT_CONFIG)"/>


### PR DESCRIPTION
Introduces OM_DOCKING_WAIT_TIME and OM_UNDOCKING_WAIT_TIME options to allow for a configurable delay before the mower starts the docking approach and before it begins undocking from the chargingstation.

This provides flexibility in scenarios where a waiting period is beneficial, such as opening a mower garage listening to MQTT states