### PR TITLE
README.md: remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Currently, the following repositories are included:
 
 OpenMower requires ROS Noetic. ([installation instruction](http://wiki.ros.org/noetic/Installation)) There is no distributed release package yet, for development and test purpose it's best to build the workspace on your own.
 
-By default, OpenMower is supposed to run on an ARM-based Raspberry boards: https://x-tech.online/2022/01/installing-ros-noetic-on-a-headless-raspberry-pi-4-with-ubuntu-20-04/
-
 #### Fetch Dependencies
 Before building, you need to fetch this project's dependencies. The best way to do this is by using rosdep:
 


### PR DESCRIPTION
Old link is not valid any more and gives the following:

Server Error
404
Page Not Found
This page either doesn't exist, or it moved somewhere else.

![Screenshot 2025-06-07 at 21 33 49](https://github.com/user-attachments/assets/7afdb5a5-d347-4dd5-8acd-fb1a6286580a)
