### PR TITLE
Fix/gps power in mower status

### DIFF
--- a/src/mower_comms_v1/src/mower_comms.cpp
+++ b/src/mower_comms_v1/src/mower_comms.cpp
@@ -219,7 +219,7 @@ void publishStatus() {
   }
 
   status_msg.raspberry_pi_power = (last_ll_status.status_bitmask & 0b00000010) != 0;
-  status_msg.gps_power = (last_ll_status.status_bitmask & 0b00000100) != 0;
+  status_msg.is_charging = (last_ll_status.status_bitmask & 0b00000100) != 0;
   status_msg.esc_power = (last_ll_status.status_bitmask & 0b00001000) != 0;
   status_msg.rain_detected = (last_ll_status.status_bitmask & 0b00010000) != 0;
   status_msg.sound_module_available = (last_ll_status.status_bitmask & 0b00100000) != 0;

--- a/src/mower_msgs/msg/Status.msg
+++ b/src/mower_msgs/msg/Status.msg
@@ -8,7 +8,7 @@ time stamp
 # Initialized or not
 uint8 mower_status
 bool raspberry_pi_power
-bool gps_power
+bool is_charging
 bool esc_power
 bool rain_detected
 bool sound_module_available


### PR DESCRIPTION
**Observed behavior**
`rostopic echo -n 1 /ll/mower_status` yields 
- `gps_power: True` when chraging/in dock
- `gps_power: False` else
This probably has nothing to do with what `gps_power` may make the user think.

**Analysis**
`rostopic echo -n 1 /xbot_monitoring/robot_state` yields `is_charging: True`. Both reference the same position in the status vector and `is_charging` fits the observed behavior. So the ssumption ist, that it's imply a wrong labeling in `/ll/mower_status`

**Solution**
I replaced the two occurrences of `gps_power` in the `open_mower_ros` repository by `is_charging` to make the outputs of both topics consistent.

**Why**
People looking for problems with their GPS will be confused by the output and may be led in the wrong direction in their analysis. Unnecessary communication on discord related to the simplicity of the solution - if I haven't missed anything

**Testing done**
I built the container in my fork, deployed it on the mower, did the two `rostopic` commands to verify the change (ok) and started mowing. Everything seems to be fine. (platform: Yard Force 500c, latest releases-edge, v1 hardware with v1 config)

**Annotation for review**
I don't know enough about the connections and can't judge whether this change might break subtle (external) interfaces. 
