### PR TITLE
Fetch submodules in workflow, not during build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -54,6 +54,8 @@ jobs:
       # Get the repository's code
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       # Setup Python 3
       - name: Set up Python

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,17 +19,7 @@ COPY --link ./docker/assets/nginx.conf /etc/nginx/conf.d/default.conf
 # Update rosdep
 RUN rosdep update --rosdistro $ROS_DISTRO
 
-# First stage: Pull the git and all submodules, other stages depend on it
-FROM base AS fetch
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-COPY --link ./ /opt/open_mower_ros
-
-WORKDIR /opt/open_mower_ros
-
-RUN git submodule update --init --recursive
-
+####################################################################################################
 
 # Get slic3r_coverage_planner and build that. We will pull the finished install folder from this.
 # This stage should cache most of the time, that's why it's not derived from the fetch stage, but copies stuff instead.
@@ -38,7 +28,7 @@ FROM base AS slic3r
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Fetch the slic3r planner from the repo (this will cache if unchanged)
-COPY --link --from=fetch /opt/open_mower_ros/src/lib/slic3r_coverage_planner /opt/slic3r_coverage_planner_workspace/src
+COPY --link src/lib/slic3r_coverage_planner /opt/slic3r_coverage_planner_workspace/src
 
 WORKDIR /opt/slic3r_coverage_planner_workspace
 RUN rosdep install --from-paths src --ignore-src --simulate | \
@@ -48,23 +38,26 @@ RUN rosdep install --from-paths src --ignore-src --simulate | \
 RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make"
 RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
 
+####################################################################################################
 
 # Fetch the repo and assemble the list of dependencies. We will pull these in the next step and actually run install on them
 # If the package list is the same as last time, the apt install step is cached as well which saves a lot of time.
 # Since the list gets sorted, it will be the same each time and the cache will know that by file checksum in the COPY command.
 # We can't use this stage as base for the next, because this stage is run every time and would therefore invalidate the cache of the next stage.
-FROM fetch AS dependencies
+FROM base AS dependencies
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /opt/open_mower_ros
 
 # This creates the sorted list of apt-get install commands.
-RUN apt-get update && \
+RUN --mount=type=bind,source=src,target=src \
+    apt-get update && \
     rosdep install --from-paths src --ignore-src --simulate | \
     sed --expression '1d' | sort | tr -d '\n' | sed --expression 's/  apt-get install//g' > /apt-install_list \
     && rm -rf /var/lib/apt/lists/*
 
+####################################################################################################
 
 # We can't derive this from "dependencies" because "dependencies" will be rebuilt every time, but apt install should only be done if needed
 FROM base AS assemble
@@ -80,8 +73,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends --yes $(cat /apt-install_list) libasio-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# This will already have the submodules initialized, no need to clone again
-COPY --link --from=fetch /opt/open_mower_ros /opt/open_mower_ros
+COPY --link ./ /opt/open_mower_ros
 
 #delete prebuilt libs (so that they won't shadow the preinstalled ones)
 RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list


### PR DESCRIPTION
This makes it possible to add .git* and others to .dockerignore. This isn't done in this commit because it breaks version_info.env generation.