### PR TITLE
Expose rain_detected flag to robot_state/json mqtt topic

### DIFF
--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -369,6 +369,7 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     j["current_path_index"] = msg->current_path_index;
     j["emergency"] = msg->emergency;
     j["is_charging"] = msg->is_charging;
+    j["rain_detected"] = msg->rain_detected;
     j["pose"]["x"] = msg->robot_pose.pose.pose.position.x;
     j["pose"]["y"] = msg->robot_pose.pose.pose.position.y;
     j["pose"]["heading"] = msg->robot_pose.vehicle_heading;

--- a/src/lib/xbot_msgs/msg/RobotState.msg
+++ b/src/lib/xbot_msgs/msg/RobotState.msg
@@ -10,3 +10,4 @@ int16 current_area
 int16 current_path
 int16 current_path_index
 xbot_msgs/AbsolutePose robot_pose # Pose of the docking station
+bool rain_detected

--- a/src/lib/xbot_msgs/msg/RobotState.msg
+++ b/src/lib/xbot_msgs/msg/RobotState.msg
@@ -2,6 +2,7 @@
 float32 battery_percentage
 bool emergency
 bool is_charging
+bool rain_detected
 float32 gps_percentage
 float32 current_action_progress
 string current_state                # Like "Cleaning"
@@ -10,4 +11,3 @@ int16 current_area
 int16 current_path
 int16 current_path_index
 xbot_msgs/AbsolutePose robot_pose # Pose of the docking station
-bool rain_detected

--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -107,6 +107,7 @@ void status_received(StatusPtr &msg) {
       sc_pair.second.data_pub.publish(sensor_data);
     }
   }
+  state.rain_detected = msg->rain_detected;
 }
 
 void high_level_status(const mower_msgs::HighLevelStatus::ConstPtr &msg) {


### PR DESCRIPTION
I am using Home Assistant to control when the mower goes out to mow or when it has to return. I now managed to get the stock coverui working with the rain sensor, but discovered that the sensor information is not available through mqtt. 

This PR makes the rain_detected flag available over mqtt, so home assistant automations could use it.


