### PR TITLE
Ignore commands to mow when you would immediately abort due to rain

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -28,6 +28,7 @@ extern void setGPS(bool enabled);
 extern void setRobotPose(geometry_msgs::Pose& pose);
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
 extern ros::Time rain_resume;
+extern bool rain_detected;
 
 extern ros::ServiceClient dockingPointClient;
 extern mower_msgs::Status getStatus();
@@ -98,16 +99,19 @@ Behavior* IdleBehavior::execute() {
                              !last_config.manual_pause_mowing && !rain_delay;
 
     if (manual_start_mowing || ((automatic_mode || active_semiautomatic_task) && mower_ready)) {
-      // set the robot's position to the dock if we're actually docked
-      if (last_charge_v > 5.0) {
+      if (last_charge_v < 5.0) {
+        // Not docked, so just mow
+        setGPS(true);
+        return &MowingBehavior::INSTANCE;
+      }
+      if (last_config.rain_mode && last_status.rain_detected && rain_detected) {
+        ROS_INFO_STREAM_THROTTLE(300, "We want to mow, but its raining and we are already docked.");
+      } else {
         if (PerimeterUndockingBehavior::configured(config)) return &PerimeterUndockingBehavior::INSTANCE;
         ROS_INFO_STREAM("Currently inside the docking station, we set the robot's pose to the docks pose.");
         setRobotPose(docking_pose_stamped.pose);
         return &UndockingBehavior::INSTANCE;
       }
-      // Not docked, so just mow
-      setGPS(true);
-      return &MowingBehavior::INSTANCE;
     }
 
     if (start_area_recorder) {


### PR DESCRIPTION
Tested on my mower for a few weeks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced rain detection handling while the mower is idle and docked to better prevent unintended mowing in wet conditions.
  * Updated “mower ready” decision logic with adjusted charge-voltage thresholds, including more reliable GPS enablement and improved switching between mowing and docking/un-docking behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->