### PR TITLE
Revert "Fix bug with FLT_MIN"

### DIFF
--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -223,9 +223,9 @@ void visualizeAreas() {
 void buildMap() {
   // First, calculate the size of the map by finding the min and max values for x and y.
   float minX = FLT_MAX;
-  float maxX = -FLT_MAX;
+  float maxX = FLT_MIN;
   float minY = FLT_MAX;
-  float maxY = -FLT_MAX;
+  float maxY = FLT_MIN;
 
   // loop through all areas and calculate a size where everything fits
   for (const auto &area : mowing_areas) {


### PR DESCRIPTION
Reverts ClemensElflein/open_mower_ros#212

99% sure it was correct before.


Assume the datum is at the north-east corner of the lawn, so all recordings will be in the lower left quadrant (i.e. have negative coordinates).

Map bounds should therefore all be negative (not possible after the change).