### PR TITLE
Fix MowerControlSrvResponse typo in v2 comms

### DIFF
--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -92,7 +92,7 @@ void sendMowerEnabledTimerTask(const ros::TimerEvent &e) {
   mower_service->Tick();
 }
 
-bool setMowEnabled(mower_msgs::MowerControlSrvRequest &req, mower_msgs::MowerControlSrvRequest &res) {
+bool setMowEnabled(mower_msgs::MowerControlSrvRequest &req, mower_msgs::MowerControlSrvResponse &res) {
   mower_service->SetMowerEnabled(req.mow_enabled);
   return true;
 }


### PR DESCRIPTION
I believe this is just a typo?  It should return the Response type as in V1 comms?