### PR TITLE
Fix 'latest' Docker Tag

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -210,7 +210,7 @@ jobs:
             latest=true                    # <-- only here
       # Default, carries semver (v1.2.3) and PR/branch tags without suffix
       - name: Docker meta (Default)
-        if: (matrix.variant == 'default') && (github.event_name != 'workflow_dispatch' || inputs.variant == 'all' || inputs.variant == matrix.variant)
+        if: (matrix.variant == 'default') && (github.event_name != 'workflow_dispatch' || inputs.variant == 'all' || inputs.variant == matrix.variant) && !((github.event_name == 'push') && (github.ref == 'refs/heads/main'))
         id: meta_default
         uses: docker/metadata-action@v5
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build workflow to ensure main-branch Docker image metadata is handled by the dedicated main step, preventing duplicate/default handling on merges from other branches. This improves clarity and reliability of release builds. No functional changes to the product; behavior and features remain the same. Deployment process for non-main branches remains unchanged. No action required from users or admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->