### PR TITLE
Set entrypoint default mode to "osv1" for backward compatibility with…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,5 +97,5 @@ RUN set -eux; \
 
 USER ${USERNAME}
 
-ENTRYPOINT ["/openmower_entrypoint.sh", "osv2"]
+ENTRYPOINT ["/openmower_entrypoint.sh"]
 CMD ["bash", "-c", "roslaunch open_mower open_mower.launch --screen"]

--- a/docker/Dockerfile.Legacy
+++ b/docker/Dockerfile.Legacy
@@ -84,8 +84,8 @@ RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/sr
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo "v0.0.0")" > version_info.env
 
-COPY ./docker/openmower_entrypoint.sh /openmower_entrypoint.sh
+COPY ./docker/openmower_entrypoint.legacy.sh /openmower_entrypoint.sh
 RUN chmod +x /openmower_entrypoint.sh
 
-ENTRYPOINT ["/openmower_entrypoint.sh", "osv1"]
+ENTRYPOINT ["/openmower_entrypoint.sh"]
 CMD ["bash", "-c", "service nginx start; service mosquitto start; roslaunch open_mower open_mower.launch --screen"]

--- a/docker/openmower_entrypoint.legacy.sh
+++ b/docker/openmower_entrypoint.legacy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+source /opt/open_mower_ros/devel/setup.bash
+
+source /config/mower_config.sh
+# If OM_V2 is truthy, set HARDWARE_PLATFORM=2 and new (yaml-based) config, else 1 and environment config
+if [[ "${OM_V2,,}" =~ ^(true|1|yes)$ ]]; then
+    export HARDWARE_PLATFORM=2
+else
+    export HARDWARE_PLATFORM=1
+    export OM_LEGACY_CONFIG_MODE=True
+fi
+export ESC_TYPE=$OM_MOWER_ESC_TYPE
+export MOWER=$OM_MOWER
+# source the hardware specific default environment (default wheel ticks, antenna position etc)
+source "$(rospack find open_mower)/params/hardware_specific/$MOWER/default_environment.sh"
+
+# Set the recording path to $HOME for OSv1 to match the old behavior
+export RECORDINGS_PATH=$HOME
+export PARAMS_PATH=$HOME
+
+source /opt/open_mower_ros/version_info.env
+
+exec -- "$@"

--- a/docker/openmower_entrypoint.sh
+++ b/docker/openmower_entrypoint.sh
@@ -5,9 +5,10 @@ set -e
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 source /opt/open_mower_ros/devel/setup.bash
 
-# First arg should be mode now (osv1 or osv2)
-MODE="$1"
-if [[ -n "$MODE" ]]; then
+# Determine the mode (osv1 or osv2) from the first argument.
+# Default to osv1 if no argument is provided, to maintain compatibility with OSv1's start_ros_bash.sh which calls this entrypoint without arguments.
+MODE="${1:-osv1}"
+if [[ $# -gt 0 ]]; then
     shift
 fi
 

--- a/docker/openmower_entrypoint.sh
+++ b/docker/openmower_entrypoint.sh
@@ -4,49 +4,20 @@ set -e
 # setup ros environment
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 source /opt/open_mower_ros/devel/setup.bash
-
-# Determine the mode (osv1 or osv2) from the first argument.
-# Default to osv1 if no argument is provided, to maintain compatibility with OSv1's start_ros_bash.sh which calls this entrypoint without arguments.
-MODE="${1:-osv1}"
-if [[ $# -gt 0 ]]; then
-    shift
-fi
-
-if [[ "$MODE" == "osv1" ]]; then
-    source /config/mower_config.sh
-    # If OM_V2 is truthy, set HARDWARE_PLATFORM=2 and new (yaml-based) config, else 1 and environment config
-    if [[ "${OM_V2,,}" =~ ^(true|1|yes)$ ]]; then
-        export HARDWARE_PLATFORM=2
-    else
-        export HARDWARE_PLATFORM=1
-        export OM_LEGACY_CONFIG_MODE=True
-    fi
-    export ESC_TYPE=$OM_MOWER_ESC_TYPE
-    export MOWER=$OM_MOWER
-    # source the hardware specific default environment (default wheel ticks, antenna position etc)
-    source "$(rospack find open_mower)/params/hardware_specific/$MOWER/default_environment.sh"
-
-    # Set the recording path to $HOME for OSv1 to match the old behavior
-    export RECORDINGS_PATH=$HOME
-    export PARAMS_PATH=$HOME
-fi
-
 source /opt/open_mower_ros/version_info.env
 
 # OSv2 debugging get controlled via env var DEBUG and has the ROSCONSOLE_CONFIG_FILE embedded
 shopt -s nocasematch
-if [[ "$MODE" == "osv2" ]]; then
-    case "${DEBUG:-0}" in
-        1|true|yes|on|y)
-            export ROSOUT_DISABLE_FILE_LOGGING=False
-            unset ROSCONSOLE_CONFIG_FILE
-        ;;
-        *)
-            export ROSCONSOLE_CONFIG_FILE=/config/rosconsole.config
-            export ROSOUT_DISABLE_FILE_LOGGING=True
-        ;;
-    esac
-fi
+case "${DEBUG:-0}" in
+    1|true|yes|on|y)
+        export ROSOUT_DISABLE_FILE_LOGGING=False
+        unset ROSCONSOLE_CONFIG_FILE
+    ;;
+    *)
+        export ROSCONSOLE_CONFIG_FILE=/config/rosconsole.config
+        export ROSOUT_DISABLE_FILE_LOGGING=True
+    ;;
+esac
 shopt -u nocasematch || true
 
 exec -- "$@"


### PR DESCRIPTION
OSv1's `start_ros_bash.sh` calls the entrypoint without a args. So no MODE specific files get loaded in entrypoint.

Defaulting MODE now to "osv1".

Draft because waiting for feedback.