### PR TITLE
Fix container shell prefix and stick to color prompt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,8 @@ RUN groupadd --gid ${USER_GID} ${USERNAME} \
 COPY ./docker/assets/openmower-bashrc.sh /tmp/openmower-bashrc.sh
 RUN set -eux; \
     BRC="/home/${USERNAME}/.bashrc"; \
-    touch "$BRC"; \
+    # Uncomment force_color_prompt
+    grep -q '^#force_color_prompt=yes' "$BRC" && sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' "$BRC"; \
     chown ${USER_UID}:${USER_GID} "$BRC"; \
     printf '\n# OpenMower bashrc extension\n' >> "$BRC"; \
     cat /tmp/openmower-bashrc.sh >> "$BRC"; \

--- a/docker/assets/openmower-bashrc.sh
+++ b/docker/assets/openmower-bashrc.sh
@@ -1,9 +1,8 @@
 # This get extend user's ~/.bashrc
 
-# Interactive shells PS1 prefix opt-in via STACK_SHELL=1 to avoid non-interactive side effects.
-if [ -n "${PS1:-}" ] && [ "${STACK_SHELL:-}" = "1" ]; then
-    stack="${STACK_NAME:-openmower}"
-    export PS1="\[\e[1;34m\][${stack}]\[\e[0m\] $PS1"
+# Container shell PS1 prefix
+if command -v systemd-detect-virt >/dev/null 2>&1 && systemd-detect-virt -cq; then
+    PS1="🚜 $PS1"
 fi
 
 # Source ROS and the workspace overlay (if present)


### PR DESCRIPTION
Moved container shell prefix to here instead of OpenMowerOS. See https://github.com/ClemensElflein/OpenMowerOS/pull/27

Draft, because not yet tested.