### PR TITLE
Fixed topic name

### DIFF
--- a/src/open_mower/launch/include/_comms.launch
+++ b/src/open_mower/launch/include/_comms.launch
@@ -18,7 +18,7 @@
                 respawn_delay="5"
                 unless="$(optenv OM_NO_GPS False)">
             <remap from="/ll/services/rtcm" to="/ll/position/gps/rtcm"/>
-            <remap from="/ll/services/nmea" to="/ll/position/gps/nmea"/>
+            <remap from="/nmea" to="/ll/position/gps/nmea"/>
             <remap from="~xb_pose" to="/ll/position/gps"/>
             <remap from="~wheel_ticks" to="/mower/wheel_ticks"/>
         </node>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated GPS NMEA topic remap: the source topic changed from /ll/services/nmea to /nmea; the destination remains /ll/position/gps/nmea.
  - No other remaps were modified.
  - Impact: Publishers of NMEA data must publish to /nmea for the GPS node to receive messages; downstream consumers of /ll/position/gps/nmea are unaffected.
  - Verify any custom launch or integration scripts that referenced the previous source topic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->