### PR TITLE
Provide explicit NTRIP version when connecting

### DIFF
--- a/src/open_mower/launch/include/_ntrip_client.launch
+++ b/src/open_mower/launch/include/_ntrip_client.launch
@@ -4,7 +4,7 @@
 
     <!-- Declare arguments with default values -->
     <arg name="authenticate" default="true"/>
-    <arg name="ntrip_version" default=""/>
+    <arg name="ntrip_version" default="Ntrip/2.0"/>
     <arg name="ssl" default="false"/>
     <arg name="cert" default=""/>
     <arg name="key" default=""/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default NTRIP version to **"Ntrip/2.0"** in the NTRIP client launch configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->