### PR TITLE
Publish position and events via MQTT

### DIFF
--- a/src/lib/xbot_monitoring/CMakeLists.txt
+++ b/src/lib/xbot_monitoring/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
         grid_map_ros
         grid_map_msgs
         xbot_mqtt
+        mower_msgs
         )
 
 
@@ -31,6 +32,7 @@ catkin_package(
         #  LIBRARIES mower_comms
         #  CATKIN_DEPENDS mower_msgs roscpp serial
         #  DEPENDS system_lib
+        CATKIN_DEPENDS mower_msgs
         DEPENDS PahoMqttCpp
 
 )

--- a/src/lib/xbot_monitoring/package.xml
+++ b/src/lib/xbot_monitoring/package.xml
@@ -23,6 +23,7 @@
   <depend>grid_map_ros</depend>
   <depend>grid_map_msgs</depend>
   <depend>xbot_mqtt</depend>
+  <depend>mower_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/src/lib/xbot_monitoring/src/EventHistory.h
+++ b/src/lib/xbot_monitoring/src/EventHistory.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <deque>
+#include <fstream>
+#include <mutex>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::ordered_json;
+
+class EventHistory {
+public:
+    EventHistory() = default;
+
+    void init(size_t max_size) {
+        max_size_ = max_size;
+        file_path_ = "events.jsonl";
+        loadFromDisk();
+    }
+
+    // Appends a raw JSON string to the ring buffer and persists it.
+    // No JSON parsing — stored as-is, parsed only on getAll().
+    void add(const std::string& json_payload) {
+        std::lock_guard<std::mutex> lk(mutex_);
+        if (buffer_.size() >= max_size_) {
+            buffer_.pop_front();
+        }
+        buffer_.push_back(json_payload);
+        appendToDisk(json_payload);
+    }
+
+    // Returns all buffered events as a JSON array. Parses on read.
+    json getAll() const {
+        std::lock_guard<std::mutex> lk(mutex_);
+        json arr = json::array();
+        for (const auto& line : buffer_) {
+            try {
+                arr.push_back(json::parse(line));
+            } catch (...) {
+                // skip malformed lines
+            }
+        }
+        return arr;
+    }
+
+private:
+    void loadFromDisk() {
+        std::ifstream f(file_path_);
+        if (!f.is_open()) return;
+        std::string line;
+        while (std::getline(f, line)) {
+            if (line.empty()) continue;
+            if (buffer_.size() >= max_size_) buffer_.pop_front();
+            buffer_.push_back(std::move(line));
+        }
+    }
+
+    void appendToDisk(const std::string& json_payload) {
+        std::ofstream f(file_path_, std::ios::app);
+        if (f.is_open()) {
+            f << json_payload << "\n";
+        }
+    }
+
+    std::string file_path_;
+    size_t max_size_ = 100;
+    std::deque<std::string> buffer_;
+    mutable std::mutex mutex_;
+};

--- a/src/lib/xbot_monitoring/src/EventHistory.h
+++ b/src/lib/xbot_monitoring/src/EventHistory.h
@@ -91,9 +91,10 @@ class EventHistory {
  private:
   static std::string todayString() {
     std::time_t t = std::time(nullptr);
-    std::tm* lt = std::localtime(&t);
+    std::tm tm_result{};
+    localtime_r(&t, &tm_result);
     char buf[9];
-    std::strftime(buf, sizeof(buf), "%Y%m%d", lt);
+    std::strftime(buf, sizeof(buf), "%Y%m%d", &tm_result);
     return buf;
   }
 

--- a/src/lib/xbot_monitoring/src/EventHistory.h
+++ b/src/lib/xbot_monitoring/src/EventHistory.h
@@ -1,70 +1,150 @@
 #pragma once
 
-#include <deque>
+#include <algorithm>
+#include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
-#include <string>
-
 #include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
 
 using json = nlohmann::ordered_json;
 
 class EventHistory {
-public:
-    EventHistory() = default;
+ public:
+  EventHistory() = default;
 
-    void init(size_t max_size) {
-        max_size_ = max_size;
-        file_path_ = "events.jsonl";
-        loadFromDisk();
+  void init() {
+    base_dir_ = "event_history";
+    std::filesystem::create_directories(base_dir_);
+    current_date_ = todayString();
+    today_buffer_ = readLines(base_dir_ + "/" + current_date_ + ".jsonl");
+    dir_index_ = scanDir();
+  }
+
+  // Appends a raw JSON string. Persists to today's file.
+  // On day rollover the in-memory buffer is cleared and a new file is started.
+  void add(const std::string& json_payload) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    std::string date = todayString();
+    if (date != current_date_) {
+      today_buffer_.clear();
+      current_date_ = date;
+      // New day: today's file doesn't exist yet, add it to the index front.
+      dir_index_.insert(dir_index_.begin(), current_date_);
     }
+    today_buffer_.push_back(json_payload);
+    appendToDisk(json_payload);
+  }
 
-    // Appends a raw JSON string to the ring buffer and persists it.
-    // No JSON parsing — stored as-is, parsed only on getAll().
-    void add(const std::string& json_payload) {
-        std::lock_guard<std::mutex> lk(mutex_);
-        if (buffer_.size() >= max_size_) {
-            buffer_.pop_front();
-        }
-        buffer_.push_back(json_payload);
-        appendToDisk(json_payload);
+  // Returns today's events as a JSON array of objects (parsed on read).
+  json getAll() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return parseBuffer(today_buffer_);
+  }
+
+  // Returns events for the given date as a JSON array of objects.
+  // If date matches today or is empty, served from memory.
+  // Otherwise read fresh from disk. Missing file → empty array.
+  json getAll(const std::string& date) const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (date.empty() || date == current_date_) {
+      return parseBuffer(today_buffer_);
     }
+    return parseBuffer(readLines(base_dir_ + "/" + date + ".jsonl"));
+  }
 
-    // Returns all buffered events as a JSON array. Parses on read.
-    json getAll() const {
-        std::lock_guard<std::mutex> lk(mutex_);
-        json arr = json::array();
-        for (const auto& line : buffer_) {
-            try {
-                arr.push_back(json::parse(line));
-            } catch (...) {
-                // skip malformed lines
-            }
-        }
-        return arr;
+  // Deletes the file for the given date. If date is empty/nullopt, deletes ALL files.
+  // Deleting today also clears the in-memory buffer.
+  // Returns {"deleted": N}.
+  json deleteHistory(const std::optional<std::string>& date) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    int deleted = 0;
+    for (auto it = dir_index_.begin(); it != dir_index_.end();) {
+      if (date.has_value() && *it != *date) {
+        ++it;
+        continue;
+      }
+      std::error_code ec;
+      if (std::filesystem::remove(base_dir_ + "/" + *it + ".jsonl", ec)) {
+        if (*it == current_date_) today_buffer_.clear();
+        ++deleted;
+        it = dir_index_.erase(it);
+      } else {
+        ++it;
+      }
     }
+    return {{"deleted", deleted}};
+  }
 
-private:
-    void loadFromDisk() {
-        std::ifstream f(file_path_);
-        if (!f.is_open()) return;
-        std::string line;
-        while (std::getline(f, line)) {
-            if (line.empty()) continue;
-            if (buffer_.size() >= max_size_) buffer_.pop_front();
-            buffer_.push_back(std::move(line));
-        }
+  // Returns available dates newest-first: ["20260612", "20260611", ...]
+  // Only dates for which a file exists are returned.
+  json listHistories() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    json arr = json::array();
+    for (const auto& d : dir_index_) arr.push_back(d);
+    return arr;
+  }
+
+ private:
+  static std::string todayString() {
+    std::time_t t = std::time(nullptr);
+    std::tm* lt = std::localtime(&t);
+    char buf[9];
+    std::strftime(buf, sizeof(buf), "%Y%m%d", lt);
+    return buf;
+  }
+
+  // Scans base_dir_ once and returns dates newest-first for all *.jsonl files
+  // whose stem is exactly 8 characters (YYYYMMDD).
+  std::vector<std::string> scanDir() const {
+    std::vector<std::string> dates;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(base_dir_, ec)) {
+      if (!entry.is_regular_file()) continue;
+      const std::string name = entry.path().filename().string();
+      if (name.size() != 13 || name.substr(8) != ".jsonl") continue;
+      dates.push_back(name.substr(0, 8));
     }
+    std::sort(dates.begin(), dates.end(), std::greater<std::string>());
+    return dates;
+  }
 
-    void appendToDisk(const std::string& json_payload) {
-        std::ofstream f(file_path_, std::ios::app);
-        if (f.is_open()) {
-            f << json_payload << "\n";
-        }
+  static std::vector<std::string> readLines(const std::string& path) {
+    std::vector<std::string> lines;
+    std::ifstream f(path);
+    if (!f.is_open()) return lines;
+    std::string line;
+    while (std::getline(f, line)) {
+      if (!line.empty()) lines.push_back(std::move(line));
     }
+    return lines;
+  }
 
-    std::string file_path_;
-    size_t max_size_ = 100;
-    std::deque<std::string> buffer_;
-    mutable std::mutex mutex_;
+  static json parseBuffer(const std::vector<std::string>& buf) {
+    json arr = json::array();
+    for (const auto& line : buf) {
+      try {
+        arr.push_back(json::parse(line));
+      } catch (...) {
+        // skip malformed lines
+      }
+    }
+    return arr;
+  }
+
+  void appendToDisk(const std::string& json_payload) {
+    std::ofstream f(base_dir_ + "/" + current_date_ + ".jsonl", std::ios::app);
+    if (f.is_open()) {
+      f << json_payload << "\n";
+    }
+  }
+
+  std::string base_dir_;
+  std::string current_date_;
+  std::vector<std::string> today_buffer_;
+  std::vector<std::string> dir_index_;  // dates newest-first, populated at init, updated on day rollover
+  mutable std::mutex mutex_;
 };

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -39,6 +39,10 @@ using json = nlohmann::ordered_json;
 
 class PositionHistory {
  public:
+  struct TrackAttributes {
+    bool blades = false;
+  };
+
   PositionHistory() = default;
 
   void init() {
@@ -83,6 +87,11 @@ class PositionHistory {
     writePending();
   }
 
+  TrackAttributes getAttributes() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return current_attributes_;
+  }
+
   // Returns all segments (including the open tail) as a JSON array for client seeding.
   // Format: [{"blades": bool, "points": [[x,y], ...]}, ...]
   json getHistory() const {
@@ -114,10 +123,6 @@ class PositionHistory {
   struct TaggedPoint {
     double x, y;
     bool committable;
-  };
-
-  struct TrackAttributes {
-    bool blades = false;
   };
 
   struct Segment {
@@ -411,3 +416,5 @@ class PositionHistory {
 
   mutable std::mutex mutex_;
 };
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PositionHistory::TrackAttributes, blades)

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <ros/ros.h>
+
+#include <algorithm>
+#include <cmath>
+#include <deque>
+#include <fstream>
+#include <functional>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+using json = nlohmann::ordered_json;
+
+class PositionHistory {
+ public:
+  PositionHistory() = default;
+
+  void init(size_t max_segments, size_t simplify_threshold = 500) {
+    file_path_ = "positions.jsonl";
+    max_segments_ = max_segments;
+    simplify_threshold_ = simplify_threshold;
+    loadFromDisk();
+    startNewSegment();
+  }
+
+  // Appends a raw point to the current open segment.
+  // Closes segment if point count exceeds threshold to prevent unbounded memory usage.
+  void addPoint(double x, double y, ros::Time t) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (current_.points.empty()) {
+      current_.start_time = t;
+    }
+    current_.points.push_back({x, y});
+    if (current_.points.size() >= simplify_threshold_) {
+      startNewSegment();
+    }
+  }
+
+  // Closes the current segment and opens a new one.
+  // mow_enabled flips only on "MOWING_STARTED" / "MOWING_STOPPED".
+  void onEvent(const std::string& type) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (type == "MOWING_STARTED") {
+      current_mow_enabled_ = true;
+    } else if (type == "MOWING_STOPPED") {
+      current_mow_enabled_ = false;
+    }
+    startNewSegment();
+  }
+
+  // Simplifies and persists the current open segment.
+  // Call on ROS shutdown to avoid losing in-progress track data.
+  void flush() {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (current_.points.empty()) return;
+    startNewSegment();
+  }
+
+  // Returns all closed segments as a JSON array.
+  json getHistory() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    json arr = json::array();
+    for (const auto& seg : closed_segments_) {
+      arr.push_back(segmentToJson(seg));
+    }
+    return arr;
+  }
+
+ private:
+  struct Segment {
+    ros::Time start_time;
+    bool mow_enabled = false;
+    std::vector<std::pair<double, double>> points;
+  };
+
+  void startNewSegment() {
+    // Simplify and persist the current segment if it has points.
+    if (!current_.points.empty()) {
+      Segment simplified = current_;
+      simplified.points = rdp(current_.points, 0.02);
+      if (closed_segments_.size() >= max_segments_) {
+        closed_segments_.pop_front();
+      }
+      closed_segments_.push_back(simplified);
+      persistSegment(simplified);
+    }
+
+    // Start a new segment.
+    current_ = Segment{};
+    current_.mow_enabled = current_mow_enabled_;
+  }
+
+  void persistSegment(const Segment& seg) {
+    std::string data = segmentToJson(seg).dump();
+    std::lock_guard<std::mutex> lock(file_mutex_);
+    std::ofstream f(file_path_, std::ios::app);
+    if (f.is_open()) {
+      f << data << "\n";
+    }
+  }
+
+  void loadFromDisk() {
+    std::ifstream f(file_path_);
+    if (!f.is_open()) return;
+    std::string line;
+    while (std::getline(f, line)) {
+      if (line.empty()) continue;
+      try {
+        json j = json::parse(line);
+        Segment seg;
+        seg.start_time = ros::Time(j["start_time"].get<double>());
+        seg.mow_enabled = j["mow_enabled"].get<bool>();
+        for (const auto& pt : j["points"]) {
+          seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
+        }
+        if (closed_segments_.size() >= max_segments_) {
+          closed_segments_.pop_front();
+        }
+        closed_segments_.push_back(seg);
+      } catch (...) {
+        // skip malformed lines
+      }
+    }
+  }
+
+  static json segmentToJson(const Segment& seg) {
+    json pts = json::array();
+    for (const auto& p : seg.points) {
+      pts.push_back({p.first, p.second});
+    }
+    return {{"start_time", seg.start_time.toSec()}, {"mow_enabled", seg.mow_enabled}, {"points", pts}};
+  }
+
+  // Ramer-Douglas-Peucker line simplification.
+  static double perpendicularDistance(const std::pair<double, double>& p, const std::pair<double, double>& a,
+                                      const std::pair<double, double>& b) {
+    double dx = b.first - a.first;
+    double dy = b.second - a.second;
+    double len2 = dx * dx + dy * dy;
+    if (len2 == 0.0) {
+      dx = p.first - a.first;
+      dy = p.second - a.second;
+      return std::sqrt(dx * dx + dy * dy);
+    }
+    double t = ((p.first - a.first) * dx + (p.second - a.second) * dy) / len2;
+    t = std::max(0.0, std::min(1.0, t));
+    double projx = a.first + t * dx;
+    double projy = a.second + t * dy;
+    dx = p.first - projx;
+    dy = p.second - projy;
+    return std::sqrt(dx * dx + dy * dy);
+  }
+
+  static void rdpRecursive(const std::vector<std::pair<double, double>>& pts, size_t start, size_t end, double epsilon,
+                           std::vector<bool>& keep) {
+    if (end <= start + 1) return;
+    double max_dist = 0.0;
+    size_t max_idx = start;
+    for (size_t i = start + 1; i < end; ++i) {
+      double d = perpendicularDistance(pts[i], pts[start], pts[end]);
+      if (d > max_dist) {
+        max_dist = d;
+        max_idx = i;
+      }
+    }
+    if (max_dist > epsilon) {
+      keep[max_idx] = true;
+      rdpRecursive(pts, start, max_idx, epsilon, keep);
+      rdpRecursive(pts, max_idx, end, epsilon, keep);
+    }
+  }
+
+  static std::vector<std::pair<double, double>> rdp(const std::vector<std::pair<double, double>>& pts, double epsilon) {
+    if (pts.size() < 3) return pts;
+    std::vector<bool> keep(pts.size(), false);
+    keep.front() = true;
+    keep.back() = true;
+    rdpRecursive(pts, 0, pts.size() - 1, epsilon, keep);
+    std::vector<std::pair<double, double>> result;
+    result.reserve(pts.size());
+    for (size_t i = 0; i < pts.size(); ++i) {
+      if (keep[i]) result.push_back(pts[i]);
+    }
+    return result;
+  }
+
+  std::string file_path_;
+  size_t max_segments_ = 2000;
+  size_t simplify_threshold_ = 500;
+  bool current_mow_enabled_ = false;
+
+  Segment current_;
+  std::deque<Segment> closed_segments_;
+  mutable std::mutex mutex_;
+  mutable std::mutex file_mutex_;
+};

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -354,12 +354,10 @@ class PositionHistory {
     if (history_segments_.empty()) {
       Segment seg;
       seg.attributes = current_attributes_;
+      seg.started_at = ros::Time::now().toSec();
       history_segments_.push_back(std::move(seg));
     }
     Segment& tail = history_segments_.back();
-    if (tail.started_at == 0.0 && !pts.empty()) {
-      tail.started_at = ros::Time::now().toSec();
-    }
     tail.points.reserve(tail.points.size() + pts.size());
     tail.points.insert(tail.points.end(), pts.begin(), pts.end());
   }
@@ -380,6 +378,7 @@ class PositionHistory {
     if (current_attributes_.job_id.empty()) return;
     Segment seg;
     seg.attributes = current_attributes_;
+    seg.started_at = ros::Time::now().toSec();
     if (!history_segments_.empty() && !history_segments_.back().points.empty()) {
       // Prepend the last point of the previous segment as a bridge point.
       seg.points.push_back(history_segments_.back().points.back());

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <mutex>
@@ -27,12 +28,14 @@ using json = nlohmann::ordered_json;
  * a new segment is opened and a bridge vertex (last point of previous segment) is
  * prepended so segments connect.
  *
- * Persistence (append-only JSONL, two record types):
- *   {"type":"new_segment","attributes":{"job_id":"...","session_id":"...","blades":true},"points":[[x,y],...]}
- *   {"type":"append_points","points":[[x,y],...]}
+ * Persistence (one append-only JSONL per job_id, stored in position_history/):
+ *   Filename: <unix_epoch_seconds>_<job_id>.jsonl
+ *   Two record types:
+ *     {"type":"new_segment","attributes":{"job_id":"...","session_id":"...","blades":true},"points":[[x,y],...]}
+ *     {"type":"append_points","points":[[x,y],...]}
  *
- * writePending() is called ONLY from periodicFlush() (timer) and flush() (shutdown).
- * No I/O happens on addPoint(), onEvent(), or any internal state change.
+ * When job_id changes, the active file is closed (flushed) and a new one is opened.
+ * session_id / blades changes only open a new segment inside the same file.
  *
  * Pending state: written_seg_count_ tracks how many segments have had their
  * new_segment record written; written_point_count_ tracks how many points of the
@@ -50,8 +53,9 @@ class PositionHistory {
   PositionHistory() = default;
 
   void init() {
-    file_path_ = "positions.jsonl";
-    loadFromDisk();
+    base_dir_ = "position_history";
+    std::filesystem::create_directories(base_dir_);
+    initializeFromDisk();
   }
 
   // Feed a median-filtered position. Called from the pose publish timer.
@@ -68,19 +72,30 @@ class PositionHistory {
 
   // Interpret a parsed event JSON and update segment attributes accordingly.
   // Handles STATE (string job_id, string session_id) and BLADES (bool enabled).
-  // Any attribute change closes the current segment and opens a new one.
+  // A job_id change closes the current file and opens a new one.
+  // Any other attribute change closes the current segment and opens a new one.
   void onEvent(const json& event) {
     std::lock_guard<std::mutex> lk(mutex_);
     try {
       const std::string type = event.at("type").get<std::string>();
       bool changed = false;
+      bool job_changed = false;
       if (type == "STATE") {
-        changed = updateAttribute(current_attributes_.job_id, event.value("job_id", std::string{})) |
-                  updateAttribute(current_attributes_.session_id, event.value("session_id", std::string{}));
+        job_changed = updateAttribute(current_attributes_.job_id, event.value("job_id", std::string{}));
+        changed =
+            job_changed | updateAttribute(current_attributes_.session_id, event.value("session_id", std::string{}));
       } else if (type == "BLADES") {
         changed = updateAttribute(current_attributes_.blades, event.at("enabled").get<bool>());
       }
-      if (changed) {
+      if (job_changed) {
+        compact(/*flush_all=*/true);
+        writePending();
+        resetState();
+        if (!current_attributes_.job_id.empty()) {
+          startNewSegment();
+          writePending();
+        }
+      } else if (changed) {
         compact(/*flush_all=*/true);
         startNewSegment();
       }
@@ -108,23 +123,66 @@ class PositionHistory {
   }
 
   // Returns compacted segments and the raw pending buffer for client seeding.
-  // Format: {"segments": [{"attributes": {"job_id": str, "session_id": str, "blades": bool},
-  //                        "points": [[x, y], ...]}, ...],
-  //          "buffer":   [[x, y], ...]}
-  // The client should seed its own pipeline with both: segments replace history,
-  // buffer replaces the local raw buffer. Points arriving on position/json after
-  // this snapshot was taken are fed into the pipeline as usual.
+  // Always served from in-memory state (the active / latest job).
+  // Format: {"segments": [...], "buffer": [[x,y],...]}
   json getHistory() const {
     std::lock_guard<std::mutex> lk(mutex_);
-    json segs = json::array();
-    for (const auto& seg : history_segments_) {
-      segs.push_back(segmentToJson(seg));
+    return buildHistoryJson(history_segments_, rel_buffer_);
+  }
+
+  // Returns the history for a specific job_id by loading its file from disk.
+  // The active in-memory job is served from memory (no re-read).
+  // Returns {"error": "not found"} if no file for that job_id exists.
+  json getHistory(const std::string& job_id) const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (job_id == current_attributes_.job_id) {
+      return buildHistoryJson(history_segments_, rel_buffer_);
     }
-    json buf = json::array();
-    for (const auto& p : rel_buffer_) {
-      buf.push_back({p.x, p.y});
+    for (const auto& e : dir_index_) {
+      if (e.job_id == job_id) {
+        auto segs = loadFile(e.path);
+        std::vector<Point> empty_buf;
+        return buildHistoryJson(segs, empty_buf);
+      }
     }
-    return {{"segments", segs}, {"buffer", buf}};
+    return {{"error", "not found"}};
+  }
+
+  // Returns array of {job_id, timestamp} sorted newest-first (derived from filenames).
+  json listHistories() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    json arr = json::array();
+    for (const auto& e : dir_index_) {
+      arr.push_back({{"job_id", e.job_id}, {"timestamp", e.epoch}});
+    }
+    return arr;
+  }
+
+  // Deletes the file for job_id. If job_id is empty, deletes ALL files.
+  // Cannot delete the currently active job's file.
+  // Returns {"deleted": N}.
+  json deleteHistory(const std::optional<std::string>& job_id) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    int deleted = 0;
+    for (auto it = dir_index_.begin(); it != dir_index_.end();) {
+      if (job_id.has_value() && it->job_id != *job_id) {
+        ++it;
+        continue;
+      }
+      if (it->job_id == current_attributes_.job_id) {
+        // Cannot delete the current file
+        ++it;
+        continue;
+      }
+      std::error_code ec;
+      if (std::filesystem::remove(it->path, ec)) {
+        ++deleted;
+        it = dir_index_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    return {{"deleted", deleted}};
   }
 
  private:
@@ -153,6 +211,12 @@ class PositionHistory {
     std::vector<Point> points;
     TrackAttributes attributes;
     double started_at = 0.0;  // Unix time (seconds) of the first real compacted point
+  };
+
+  struct FileEntry {
+    int64_t epoch;
+    std::string job_id;
+    std::filesystem::path path;
   };
 
   // -------------------------------------------------------------------------
@@ -313,6 +377,7 @@ class PositionHistory {
 
   // Close current open segment, bridge to the new one. Called when attributes change.
   void startNewSegment() {
+    if (current_attributes_.job_id.empty()) return;
     Segment seg;
     seg.attributes = current_attributes_;
     if (!history_segments_.empty() && !history_segments_.back().points.empty()) {
@@ -335,7 +400,16 @@ class PositionHistory {
   //                          that have already been written (inside the new_segment record
   //                          or subsequent append_points records).
   //
-  // Called ONLY from periodicFlush() and flush() — never mid-operation.
+
+  // Reset in-memory state (called when job_id changes).
+  void resetState() {
+    history_segments_.clear();
+    rel_buffer_.clear();
+    written_seg_count_ = 0;
+    written_point_count_ = 0;
+    file_path_.clear();
+  }
+
   void writePending() {
     if (history_segments_.empty()) return;
 
@@ -347,6 +421,8 @@ class PositionHistory {
         written_seg_count_ > 0 && history_segments_[written_seg_count_ - 1].points.size() > written_point_count_;
     const bool new_segments = written_seg_count_ < history_segments_.size();
     if (!new_points && !new_segments) return;
+
+    if (!ensureFilePathSet()) return;
 
     std::ofstream f(file_path_, std::ios::app);
     if (!f.is_open()) {
@@ -379,9 +455,50 @@ class PositionHistory {
     }
   }
 
-  void loadFromDisk() {
-    std::ifstream f(file_path_);
-    if (!f.is_open()) return;
+  // Ensure file_path_ is set for the current job.
+  bool ensureFilePathSet() {
+    if (!file_path_.empty()) return true;
+    if (current_attributes_.job_id.empty()) return false;
+    const int64_t epoch = static_cast<int64_t>(ros::Time::now().toSec());
+    file_path_ = base_dir_ + "/" + std::to_string(epoch) + "_" + current_attributes_.job_id + ".jsonl";
+    dir_index_.insert(dir_index_.begin(), {epoch, current_attributes_.job_id, file_path_});
+    ROS_INFO_STREAM("PositionHistory: creating new file " << file_path_);
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Directory scanning and file loading
+  // -------------------------------------------------------------------------
+
+  // Parse filenames of the form "<epoch>_<job_id>.jsonl".
+  // Returns entries sorted newest-first (descending epoch).
+  std::vector<FileEntry> scanDir() const {
+    std::vector<FileEntry> entries;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(base_dir_, ec)) {
+      if (!entry.is_regular_file()) continue;
+      const std::string name = entry.path().filename().string();
+      if (name.size() < 7 || name.substr(name.size() - 6) != ".jsonl") continue;
+      const std::string stem = name.substr(0, name.size() - 6);
+      const auto sep = stem.find('_');
+      if (sep == std::string::npos || sep == 0) continue;
+      try {
+        int64_t epoch = std::stoll(stem.substr(0, sep));
+        std::string job_id = stem.substr(sep + 1);
+        if (job_id.empty()) continue;
+        entries.push_back({epoch, job_id, entry.path()});
+      } catch (...) {
+        continue;
+      }
+    }
+    std::sort(entries.begin(), entries.end(), [](const FileEntry& a, const FileEntry& b) { return a.epoch > b.epoch; });
+    return entries;
+  }
+
+  static std::vector<Segment> loadFile(const std::filesystem::path& path) {
+    std::vector<Segment> segs;
+    std::ifstream f(path);
+    if (!f.is_open()) return segs;
 
     std::string line;
     while (std::getline(f, line)) {
@@ -400,28 +517,52 @@ class PositionHistory {
           for (const auto& pt : j.at("points")) {
             seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
           }
-          history_segments_.push_back(std::move(seg));
+          segs.push_back(std::move(seg));
         } else if (type == "append_points") {
-          if (history_segments_.empty()) continue;
-          Segment& tail = history_segments_.back();
+          if (segs.empty()) continue;
+          Segment& tail = segs.back();
           for (const auto& pt : j.at("points")) {
             tail.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
           }
         }
       } catch (const std::exception& e) {
-        ROS_WARN_STREAM("PositionHistory: skipping malformed line: " << e.what());
+        ROS_WARN_STREAM("PositionHistory: skipping malformed line in " << path << ": " << e.what());
       }
     }
+    return segs;
+  }
 
-    // All loaded segments are already on disk; set watermarks accordingly.
-    // The last segment is "open" — we resume appending into it.
-    // Restore current_attributes_ from the last segment so attribute-change
-    // detection in onEvent() has the correct baseline.
+  // Load the latest file (by epoch) into in-memory state on startup.
+  // Also populates dir_index_.
+  void initializeFromDisk() {
+    dir_index_ = scanDir();
+    if (dir_index_.empty()) return;
+
+    const FileEntry& latest = dir_index_.front();
+    history_segments_ = loadFile(latest.path);
+
     if (!history_segments_.empty()) {
-      current_attributes_ = history_segments_.back().attributes;
+      // Restore only job_id so file rotation detects changes correctly.
+      // session_id and blades must come from fresh STATE/BLADES events after boot;
+      // restoring them would cause addPoint() to record while the mower is docked.
+      current_attributes_.job_id = history_segments_.back().attributes.job_id;
       written_seg_count_ = history_segments_.size();
       written_point_count_ = history_segments_.back().points.size();
+      file_path_ = latest.path.string();
+      ROS_INFO_STREAM("PositionHistory: loaded existing file " << file_path_);
     }
+  }
+
+  static json buildHistoryJson(const std::vector<Segment>& segs, const std::vector<Point>& buf) {
+    json j_segs = json::array();
+    for (const auto& seg : segs) {
+      j_segs.push_back(segmentToJson(seg));
+    }
+    json j_buf = json::array();
+    for (const auto& p : buf) {
+      j_buf.push_back({p.x, p.y});
+    }
+    return {{"segments", j_segs}, {"buffer", j_buf}};
   }
 
   static json segmentToJson(const Segment& seg) {
@@ -437,7 +578,9 @@ class PositionHistory {
             {"points", pts}};
   }
 
+  std::string base_dir_;
   std::string file_path_;
+  std::vector<FileEntry> dir_index_;  // populated once at startup, kept in sync
 
   std::vector<Point> rel_buffer_;
   std::vector<Segment> history_segments_;

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -17,16 +17,18 @@ using json = nlohmann::ordered_json;
  * Two-pass position history pipeline, mirroring the OpenMower App.
  *
  * Input: median-filtered positions arriving every ~150 ms from pose_publish_timer_callback.
+ * Points are only recorded while a mowing session is active.
  *
  * The raw buffer is compacted into history segments when it exceeds COMPACTION_THRESHOLD:
  *   1. Decimation  — drops close/same-heading points, keeping a heartbeat.
  *   2. RDP         — further simplifies the decimated result.
  *
- * Segments carry a `blades` attribute. When it changes, a new segment is opened
- * and a bridge vertex (last point of previous segment) is prepended so segments connect.
+ * Segments carry attributes (job_id, session_id, blades). When any attribute changes,
+ * a new segment is opened and a bridge vertex (last point of previous segment) is
+ * prepended so segments connect.
  *
  * Persistence (append-only JSONL, two record types):
- *   {"type":"new_segment","attributes":{"blades":true},"points":[[x,y],...]}
+ *   {"type":"new_segment","attributes":{"job_id":"...","session_id":"...","blades":true},"points":[[x,y],...]}
  *   {"type":"append_points","points":[[x,y],...]}
  *
  * writePending() is called ONLY from periodicFlush() (timer) and flush() (shutdown).
@@ -40,8 +42,9 @@ using json = nlohmann::ordered_json;
 class PositionHistory {
  public:
   struct TrackAttributes {
+    std::string job_id;
+    std::string session_id;
     bool blades = false;
-    bool idle = false;  // live-only; not persisted, not loaded
   };
 
   PositionHistory() = default;
@@ -52,8 +55,10 @@ class PositionHistory {
   }
 
   // Feed a median-filtered position. Called from the pose publish timer.
+  // Points are only recorded when a session_id is present.
   void addPoint(double x, double y) {
     std::lock_guard<std::mutex> lk(mutex_);
+    if (current_attributes_.session_id.empty()) return;
     rel_buffer_.push_back({x, y});
 
     if (rel_buffer_.size() > COMPACTION_THRESHOLD) {
@@ -62,13 +67,22 @@ class PositionHistory {
   }
 
   // Interpret a parsed event JSON and update segment attributes accordingly.
-  // Currently handles only the BLADES event.
+  // Handles STATE (string job_id, string session_id) and BLADES (bool enabled).
+  // Any attribute change closes the current segment and opens a new one.
   void onEvent(const json& event) {
     std::lock_guard<std::mutex> lk(mutex_);
     try {
       const std::string type = event.at("type").get<std::string>();
-      if (type == "BLADES") {
-        attributesChanged(current_attributes_.blades, event.at("enabled").get<bool>());
+      bool changed = false;
+      if (type == "STATE") {
+        changed = updateAttribute(current_attributes_.job_id, event.value("job_id", std::string{})) |
+                  updateAttribute(current_attributes_.session_id, event.value("session_id", std::string{}));
+      } else if (type == "BLADES") {
+        changed = updateAttribute(current_attributes_.blades, event.at("enabled").get<bool>());
+      }
+      if (changed) {
+        compact(/*flush_all=*/true);
+        startNewSegment();
       }
     } catch (const json::exception&) {
       // malformed event — ignore
@@ -94,7 +108,8 @@ class PositionHistory {
   }
 
   // Returns compacted segments and the raw pending buffer for client seeding.
-  // Format: {"segments": [{"attributes": {"blades": bool}, "points": [[x, y], ...]}, ...],
+  // Format: {"segments": [{"attributes": {"job_id": str, "session_id": str, "blades": bool},
+  //                        "points": [[x, y], ...]}, ...],
   //          "buffer":   [[x, y], ...]}
   // The client should seed its own pipeline with both: segments replace history,
   // buffer replaces the local raw buffer. Points arriving on position/json after
@@ -289,11 +304,11 @@ class PositionHistory {
   // Attribute changes
   // -------------------------------------------------------------------------
 
-  void attributesChanged(bool& current, bool new_value) {
-    if (current == new_value) return;
-    compact(/*flush_all=*/true);
-    current = new_value;
-    startNewSegment();
+  template <typename T>
+  bool updateAttribute(T& current, T new_value) {
+    if (current == new_value) return false;
+    current = std::move(new_value);
+    return true;
   }
 
   // Close current open segment, bridge to the new one. Called when attributes change.
@@ -377,7 +392,10 @@ class PositionHistory {
 
         if (type == "new_segment") {
           Segment seg;
-          seg.attributes.blades = j.at("attributes").at("blades").get<bool>();
+          const auto& attrs = j.at("attributes");
+          seg.attributes.job_id = attrs.value("job_id", std::string{});
+          seg.attributes.session_id = attrs.value("session_id", std::string{});
+          seg.attributes.blades = attrs.at("blades").get<bool>();
           seg.started_at = j.value("started_at", 0.0);
           for (const auto& pt : j.at("points")) {
             seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
@@ -411,7 +429,12 @@ class PositionHistory {
     for (const auto& p : seg.points) {
       pts.push_back({p.x, p.y});
     }
-    return {{"attributes", {{"blades", seg.attributes.blades}}}, {"started_at", seg.started_at}, {"points", pts}};
+    return {{"attributes",
+             {{"job_id", seg.attributes.job_id},
+              {"session_id", seg.attributes.session_id},
+              {"blades", seg.attributes.blades}}},
+            {"started_at", seg.started_at},
+            {"points", pts}};
   }
 
   std::string file_path_;
@@ -420,7 +443,7 @@ class PositionHistory {
   std::vector<Segment> history_segments_;
 
   // Current track attributes.
-  TrackAttributes current_attributes_{.blades = false};
+  TrackAttributes current_attributes_{};
 
   // Persistence watermarks — monotonically advance, never go backward.
   // written_seg_count_:   segments [0, written_seg_count_) have their new_segment record on disk.
@@ -431,4 +454,4 @@ class PositionHistory {
   mutable std::mutex mutex_;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PositionHistory::TrackAttributes, blades, idle)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PositionHistory::TrackAttributes, job_id, session_id, blades)

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -137,6 +137,7 @@ class PositionHistory {
   struct Segment {
     std::vector<Point> points;
     TrackAttributes attributes;
+    double started_at = 0.0;  // Unix time (seconds) of the first real compacted point
   };
 
   // -------------------------------------------------------------------------
@@ -277,6 +278,9 @@ class PositionHistory {
       history_segments_.push_back(std::move(seg));
     }
     Segment& tail = history_segments_.back();
+    if (tail.started_at == 0.0 && !pts.empty()) {
+      tail.started_at = ros::Time::now().toSec();
+    }
     tail.points.reserve(tail.points.size() + pts.size());
     tail.points.insert(tail.points.end(), pts.begin(), pts.end());
   }
@@ -374,6 +378,7 @@ class PositionHistory {
         if (type == "new_segment") {
           Segment seg;
           seg.attributes.blades = j.at("attributes").at("blades").get<bool>();
+          seg.started_at = j.value("started_at", 0.0);
           for (const auto& pt : j.at("points")) {
             seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
           }
@@ -406,7 +411,7 @@ class PositionHistory {
     for (const auto& p : seg.points) {
       pts.push_back({p.x, p.y});
     }
-    return {{"attributes", {{"blades", seg.attributes.blades}}}, {"points", pts}};
+    return {{"attributes", {{"blades", seg.attributes.blades}}}, {"started_at", seg.started_at}, {"points", pts}};
   }
 
   std::string file_path_;

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -4,197 +4,410 @@
 
 #include <algorithm>
 #include <cmath>
-#include <deque>
 #include <fstream>
-#include <functional>
+#include <limits>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <utility>
 #include <vector>
 
 using json = nlohmann::ordered_json;
+
+/*
+ * Two-pass position history pipeline, mirroring the OpenMower App.
+ *
+ * Input: median-filtered positions arriving every ~150 ms from pose_publish_timer_callback.
+ *
+ * The raw buffer is compacted into history segments when it exceeds COMPACTION_THRESHOLD:
+ *   1. Decimation  — drops close/same-heading points, keeping a heartbeat.
+ *   2. RDP         — further simplifies the decimated result.
+ *
+ * Segments carry a `blades` attribute. When it changes, a new segment is opened
+ * and a bridge vertex (last point of previous segment) is prepended so segments connect.
+ *
+ * Persistence (append-only JSONL, two record types):
+ *   {"type":"new_segment","blades":true,"points":[[x,y],...]}
+ *   {"type":"append_points","points":[[x,y],...]}
+ *
+ * writePending() is called ONLY from periodicFlush() (timer) and flush() (shutdown).
+ * No I/O happens on addPoint(), onEvent(), or any internal state change.
+ *
+ * Pending state: written_seg_count_ tracks how many segments have had their
+ * new_segment record written; written_point_count_ tracks how many points of the
+ * current tail segment have been written. Everything above those watermarks is pending.
+ */
 
 class PositionHistory {
  public:
   PositionHistory() = default;
 
-  void init(size_t max_segments, size_t simplify_threshold = 500) {
+  void init() {
     file_path_ = "positions.jsonl";
-    max_segments_ = max_segments;
-    simplify_threshold_ = simplify_threshold;
     loadFromDisk();
-    startNewSegment();
   }
 
-  // Appends a raw point to the current open segment.
-  // Closes segment if point count exceeds threshold to prevent unbounded memory usage.
-  void addPoint(double x, double y, ros::Time t) {
+  // Feed a median-filtered position. Called from the pose publish timer.
+  void addPoint(double x, double y) {
     std::lock_guard<std::mutex> lk(mutex_);
-    if (current_.points.empty()) {
-      current_.start_time = t;
-    }
-    current_.points.push_back({x, y});
-    if (current_.points.size() >= simplify_threshold_) {
-      startNewSegment();
+    rel_buffer_.push_back({x, y});
+
+    if (rel_buffer_.size() > COMPACTION_THRESHOLD) {
+      compact(/*flush_all=*/false);
     }
   }
 
-  // Closes the current segment and opens a new one.
-  // mow_enabled flips only on "MOWING_STARTED" / "MOWING_STOPPED".
-  void onEvent(const std::string& type) {
+  // Interpret a parsed event JSON and update segment attributes accordingly.
+  // Currently handles only the BLADES event.
+  void onEvent(const json& event) {
     std::lock_guard<std::mutex> lk(mutex_);
-    if (type == "MOWING_STARTED") {
-      current_mow_enabled_ = true;
-    } else if (type == "MOWING_STOPPED") {
-      current_mow_enabled_ = false;
+    try {
+      const std::string type = event.at("type").get<std::string>();
+      if (type == "BLADES") {
+        attributesChanged(current_attributes_.blades, event.at("enabled").get<bool>());
+      }
+    } catch (const json::exception&) {
+      // malformed event — ignore
     }
-    startNewSegment();
   }
 
-  // Simplifies and persists the current open segment.
-  // Call on ROS shutdown to avoid losing in-progress track data.
+  // Write pending records to disk. Call from a 30s ROS timer.
+  void periodicFlush() {
+    std::lock_guard<std::mutex> lk(mutex_);
+    writePending();
+  }
+
+  // Compact remaining buffer and write everything. Call on ROS shutdown.
   void flush() {
     std::lock_guard<std::mutex> lk(mutex_);
-    if (current_.points.empty()) return;
-    startNewSegment();
+    compact(/*flush_all=*/true);
+    writePending();
   }
 
-  // Returns all closed segments as a JSON array.
+  // Returns all segments (including the open tail) as a JSON array for client seeding.
+  // Format: [{"blades": bool, "points": [[x,y], ...]}, ...]
   json getHistory() const {
     std::lock_guard<std::mutex> lk(mutex_);
     json arr = json::array();
-    for (const auto& seg : closed_segments_) {
+    for (const auto& seg : history_segments_) {
       arr.push_back(segmentToJson(seg));
     }
     return arr;
   }
 
  private:
-  struct Segment {
-    ros::Time start_time;
-    bool mow_enabled = false;
-    std::vector<std::pair<double, double>> points;
+  // --- Compaction ---
+  static constexpr size_t COMPACTION_THRESHOLD = 60;
+  static constexpr size_t CONTEXT_WINDOW = 10;
+
+  // --- Decimation ---
+  static constexpr double DIST_THRESHOLD = 0.1;         // 10 cm
+  static constexpr double NOISE_DIST_THRESHOLD = 0.03;  // 3 cm
+  static constexpr double HEADING_THRESHOLD_RAD = 8.0 * M_PI / 180.0;
+  static constexpr size_t HEARTBEAT_POSITIONS = 10;
+  // --- RDP ---
+  static constexpr double RDP_EPSILON = 0.01;  // 1 cm
+
+  struct Point {
+    double x, y;
   };
 
-  void startNewSegment() {
-    // Simplify and persist the current segment if it has points.
-    if (!current_.points.empty()) {
-      Segment simplified = current_;
-      simplified.points = rdp(current_.points, 0.02);
-      if (closed_segments_.size() >= max_segments_) {
-        closed_segments_.pop_front();
-      }
-      closed_segments_.push_back(simplified);
-      persistSegment(simplified);
-    }
+  struct TaggedPoint {
+    double x, y;
+    bool committable;
+  };
 
-    // Start a new segment.
-    current_ = Segment{};
-    current_.mow_enabled = current_mow_enabled_;
+  struct TrackAttributes {
+    bool blades = false;
+  };
+
+  struct Segment {
+    std::vector<Point> points;
+    TrackAttributes attributes;
+  };
+
+  // -------------------------------------------------------------------------
+  // Decimation (mirrors decimate.ts)
+  // -------------------------------------------------------------------------
+  static double angleDiff(double a, double b) {
+    double d = std::fmod(std::abs(a - b), 2.0 * M_PI);
+    return d > M_PI ? 2.0 * M_PI - d : d;
   }
 
-  void persistSegment(const Segment& seg) {
-    std::string data = segmentToJson(seg).dump();
-    std::lock_guard<std::mutex> lock(file_mutex_);
+  static std::vector<TaggedPoint> decimateFilter(const std::vector<TaggedPoint>& pts) {
+    static constexpr double DIST_THRESHOLD_SQ = DIST_THRESHOLD * DIST_THRESHOLD;
+    static constexpr double NOISE_DIST_THRESH_SQ = NOISE_DIST_THRESHOLD * NOISE_DIST_THRESHOLD;
+
+    if (pts.empty()) return {};
+    std::vector<TaggedPoint> out = {pts[0]};
+    double last_heading = std::numeric_limits<double>::quiet_NaN();
+    size_t since_kept = 0;
+
+    for (size_t i = 1; i < pts.size(); ++i) {
+      const TaggedPoint& last = out.back();
+      const TaggedPoint& curr = pts[i];
+      ++since_kept;
+
+      double dx = curr.x - last.x;
+      double dy = curr.y - last.y;
+      double dist_sq = dx * dx + dy * dy;
+
+      // Only calculate and check heading if we moved enough to trust the vector
+      double heading = last_heading;
+      bool heading_changed = false;
+      if (dist_sq > NOISE_DIST_THRESH_SQ) {
+        heading = std::atan2(dy, dx);
+        heading_changed = !std::isnan(last_heading) && angleDiff(last_heading, heading) > HEADING_THRESHOLD_RAD;
+      }
+
+      if (dist_sq > DIST_THRESHOLD_SQ || heading_changed || since_kept >= HEARTBEAT_POSITIONS) {
+        out.push_back(pts[i]);
+        last_heading = heading;
+        since_kept = 0;
+      }
+    }
+    return out;
+  }
+
+  // -------------------------------------------------------------------------
+  // RDP (mirrors rdp.ts)
+  // -------------------------------------------------------------------------
+  static double pointToSegmentDistSq(const TaggedPoint& p, const TaggedPoint& a, const TaggedPoint& b) {
+    double dx = b.x - a.x;
+    double dy = b.y - a.y;
+    double len2 = dx * dx + dy * dy;
+    if (len2 == 0.0) {
+      double ex = p.x - a.x, ey = p.y - a.y;
+      return ex * ex + ey * ey;
+    }
+    double t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+    t = std::max(0.0, std::min(1.0, t));
+    double px = a.x + t * dx, py = a.y + t * dy;
+    double ex = p.x - px, ey = p.y - py;
+    return ex * ex + ey * ey;
+  }
+
+  static void rdpRecursive(const std::vector<TaggedPoint>& pts, size_t start, size_t end, std::vector<bool>& keep) {
+    static constexpr double RDP_EPSILON_SQ = RDP_EPSILON * RDP_EPSILON;
+
+    if (end <= start + 1) return;
+    double max_dist_sq = 0.0;
+    size_t max_idx = start;
+    for (size_t i = start + 1; i < end; ++i) {
+      double d_sq = pointToSegmentDistSq(pts[i], pts[start], pts[end]);
+      if (d_sq > max_dist_sq) {
+        max_dist_sq = d_sq;
+        max_idx = i;
+      }
+    }
+    if (max_dist_sq > RDP_EPSILON_SQ) {
+      keep[max_idx] = true;
+      rdpRecursive(pts, start, max_idx, keep);
+      rdpRecursive(pts, max_idx, end, keep);
+    }
+  }
+
+  static std::vector<TaggedPoint> rdpSimplify(const std::vector<TaggedPoint>& pts) {
+    if (pts.size() < 3) return pts;
+    std::vector<bool> keep(pts.size(), false);
+    keep.front() = keep.back() = true;
+    rdpRecursive(pts, 0, pts.size() - 1, keep);
+    std::vector<TaggedPoint> result;
+    result.reserve(pts.size());
+    for (size_t i = 0; i < pts.size(); ++i)
+      if (keep[i]) result.push_back(pts[i]);
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Compaction (mirrors compactToHistory in useTrack.ts)
+  // -------------------------------------------------------------------------
+  void compact(bool flush_all) {
+    if (rel_buffer_.size() <= CONTEXT_WINDOW && !flush_all) return;
+
+    // Determine how many points to commit to the current segment.
+    // Usually exclude the last CONTEXT_WINDOW points, unless flushing all.
+    const size_t points_to_commit = flush_all ? rel_buffer_.size() : rel_buffer_.size() - CONTEXT_WINDOW;
+
+    // Build the window for decimation and RDP. Include the last point of the previous segment as an anchor.
+    std::vector<TaggedPoint> window;
+    window.reserve(1 + rel_buffer_.size());  // at most 1 prefix point
+    if (!history_segments_.empty() && !history_segments_.back().points.empty()) {
+      const Point& anchor = history_segments_.back().points.back();
+      window.push_back({anchor.x, anchor.y, /*committable=*/false});
+    }
+    for (size_t i = 0; i < rel_buffer_.size(); ++i) {
+      window.push_back({rel_buffer_[i].x, rel_buffer_[i].y, /*committable=*/i < points_to_commit});
+    }
+
+    // Run decimation and RDP.
+    std::vector<TaggedPoint> decimated = decimateFilter(window);
+    std::vector<TaggedPoint> simplified = rdpSimplify(decimated);
+
+    // Append committable points (excluding the anchor and last CONTEXT_WINDOW points) to history.
+    std::vector<Point> committed;
+    for (const TaggedPoint& p : simplified) {
+      if (p.committable) committed.push_back({p.x, p.y});
+    }
+    if (!committed.empty()) {
+      appendToHistory(committed);
+    }
+
+    rel_buffer_.erase(rel_buffer_.begin(), rel_buffer_.begin() + points_to_commit);
+  }
+
+  // Append committed points to the current open segment (or start one).
+  void appendToHistory(const std::vector<Point>& pts) {
+    if (history_segments_.empty()) {
+      Segment seg;
+      seg.attributes = current_attributes_;
+      history_segments_.push_back(std::move(seg));
+    }
+    Segment& tail = history_segments_.back();
+    tail.points.reserve(tail.points.size() + pts.size());
+    tail.points.insert(tail.points.end(), pts.begin(), pts.end());
+  }
+
+  // -------------------------------------------------------------------------
+  // Attribute changes
+  // -------------------------------------------------------------------------
+
+  void attributesChanged(bool& current, bool new_value) {
+    if (current == new_value) return;
+    compact(/*flush_all=*/true);
+    current = new_value;
+    startNewSegment();
+  }
+
+  // Close current open segment, bridge to the new one. Called when attributes change.
+  void startNewSegment() {
+    Segment seg;
+    seg.attributes = current_attributes_;
+    if (!history_segments_.empty() && !history_segments_.back().points.empty()) {
+      // Prepend the last point of the previous segment as a bridge point.
+      seg.points.push_back(history_segments_.back().points.back());
+    }
+    history_segments_.push_back(std::move(seg));
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence
+  // -------------------------------------------------------------------------
+  //
+  // Watermarks:
+  //   written_seg_count_   — number of segments whose new_segment record has been written.
+  //                          Segments [0, written_seg_count_) are fully on disk.
+  //                          Segment written_seg_count_-1 may have more points pending
+  //                          (tracked by written_point_count_).
+  //   written_point_count_ — number of points of history_segments_[written_seg_count_-1]
+  //                          that have already been written (inside the new_segment record
+  //                          or subsequent append_points records).
+  //
+  // Called ONLY from periodicFlush() and flush() — never mid-operation.
+  void writePending() {
+    if (history_segments_.empty()) return;
+
+    // Check if there is anything to write at all.
+    // There is work if:
+    //   a) any segment starting from written_seg_count_ has not had its record written, or
+    //   b) the last written segment has grown beyond written_point_count_.
+    const bool new_points =
+        written_seg_count_ > 0 && history_segments_[written_seg_count_ - 1].points.size() > written_point_count_;
+    const bool new_segments = written_seg_count_ < history_segments_.size();
+    if (!new_points && !new_segments) return;
+
     std::ofstream f(file_path_, std::ios::app);
-    if (f.is_open()) {
-      f << data << "\n";
+    if (!f.is_open()) {
+      ROS_WARN_STREAM("PositionHistory: could not open " << file_path_ << " for writing");
+      return;
+    }
+
+    // Append any new points that arrived in the current tail segment since the last write.
+    if (new_points) {
+      json j = {{"type", "append_points"}};
+      json points = json::array();
+      const Segment& tail = history_segments_[written_seg_count_ - 1];
+      for (auto it = tail.points.begin() + written_point_count_; it != tail.points.end(); ++it) {
+        points.push_back({it->x, it->y});
+      }
+      j["points"] = points;
+      f << j.dump() << "\n";
+      written_point_count_ = tail.points.size();
+    }
+
+    // Write new_segment records for every segment that hasn't been written yet.
+    // Each carries all points accumulated so far in that segment (could be just a
+    // bridge point, or bridge + some compacted points).
+    for (auto it = history_segments_.begin() + written_seg_count_; it != history_segments_.end(); ++it) {
+      json j = {{"type", "new_segment"}};
+      j.update(segmentToJson(*it));
+      f << j.dump() << "\n";
+      ++written_seg_count_;
+      written_point_count_ = it->points.size();
     }
   }
 
   void loadFromDisk() {
     std::ifstream f(file_path_);
     if (!f.is_open()) return;
+
     std::string line;
     while (std::getline(f, line)) {
       if (line.empty()) continue;
       try {
         json j = json::parse(line);
-        Segment seg;
-        seg.start_time = ros::Time(j["start_time"].get<double>());
-        seg.mow_enabled = j["mow_enabled"].get<bool>();
-        for (const auto& pt : j["points"]) {
-          seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
+        std::string type = j.at("type").get<std::string>();
+
+        if (type == "new_segment") {
+          Segment seg;
+          seg.attributes.blades = j.at("blades").get<bool>();
+          for (const auto& pt : j.at("points")) {
+            seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
+          }
+          history_segments_.push_back(std::move(seg));
+        } else if (type == "append_points") {
+          if (history_segments_.empty()) continue;
+          Segment& tail = history_segments_.back();
+          for (const auto& pt : j.at("points")) {
+            tail.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
+          }
         }
-        if (closed_segments_.size() >= max_segments_) {
-          closed_segments_.pop_front();
-        }
-        closed_segments_.push_back(seg);
-      } catch (...) {
-        // skip malformed lines
+      } catch (const std::exception& e) {
+        ROS_WARN_STREAM("PositionHistory: skipping malformed line: " << e.what());
       }
+    }
+
+    // All loaded segments are already on disk; set watermarks accordingly.
+    // The last segment is "open" — we resume appending into it.
+    // Restore current_attributes_ from the last segment so attribute-change
+    // detection in onEvent() has the correct baseline.
+    if (!history_segments_.empty()) {
+      current_attributes_ = history_segments_.back().attributes;
+      written_seg_count_ = history_segments_.size();
+      written_point_count_ = history_segments_.back().points.size();
     }
   }
 
   static json segmentToJson(const Segment& seg) {
     json pts = json::array();
     for (const auto& p : seg.points) {
-      pts.push_back({p.first, p.second});
+      pts.push_back({p.x, p.y});
     }
-    return {{"start_time", seg.start_time.toSec()}, {"mow_enabled", seg.mow_enabled}, {"points", pts}};
-  }
-
-  // Ramer-Douglas-Peucker line simplification.
-  static double perpendicularDistance(const std::pair<double, double>& p, const std::pair<double, double>& a,
-                                      const std::pair<double, double>& b) {
-    double dx = b.first - a.first;
-    double dy = b.second - a.second;
-    double len2 = dx * dx + dy * dy;
-    if (len2 == 0.0) {
-      dx = p.first - a.first;
-      dy = p.second - a.second;
-      return std::sqrt(dx * dx + dy * dy);
-    }
-    double t = ((p.first - a.first) * dx + (p.second - a.second) * dy) / len2;
-    t = std::max(0.0, std::min(1.0, t));
-    double projx = a.first + t * dx;
-    double projy = a.second + t * dy;
-    dx = p.first - projx;
-    dy = p.second - projy;
-    return std::sqrt(dx * dx + dy * dy);
-  }
-
-  static void rdpRecursive(const std::vector<std::pair<double, double>>& pts, size_t start, size_t end, double epsilon,
-                           std::vector<bool>& keep) {
-    if (end <= start + 1) return;
-    double max_dist = 0.0;
-    size_t max_idx = start;
-    for (size_t i = start + 1; i < end; ++i) {
-      double d = perpendicularDistance(pts[i], pts[start], pts[end]);
-      if (d > max_dist) {
-        max_dist = d;
-        max_idx = i;
-      }
-    }
-    if (max_dist > epsilon) {
-      keep[max_idx] = true;
-      rdpRecursive(pts, start, max_idx, epsilon, keep);
-      rdpRecursive(pts, max_idx, end, epsilon, keep);
-    }
-  }
-
-  static std::vector<std::pair<double, double>> rdp(const std::vector<std::pair<double, double>>& pts, double epsilon) {
-    if (pts.size() < 3) return pts;
-    std::vector<bool> keep(pts.size(), false);
-    keep.front() = true;
-    keep.back() = true;
-    rdpRecursive(pts, 0, pts.size() - 1, epsilon, keep);
-    std::vector<std::pair<double, double>> result;
-    result.reserve(pts.size());
-    for (size_t i = 0; i < pts.size(); ++i) {
-      if (keep[i]) result.push_back(pts[i]);
-    }
-    return result;
+    return {{"blades", seg.attributes.blades}, {"points", pts}};
   }
 
   std::string file_path_;
-  size_t max_segments_ = 2000;
-  size_t simplify_threshold_ = 500;
-  bool current_mow_enabled_ = false;
 
-  Segment current_;
-  std::deque<Segment> closed_segments_;
+  std::vector<Point> rel_buffer_;
+  std::vector<Segment> history_segments_;
+
+  // Current track attributes.
+  TrackAttributes current_attributes_{.blades = false};
+
+  // Persistence watermarks — monotonically advance, never go backward.
+  // written_seg_count_:   segments [0, written_seg_count_) have their new_segment record on disk.
+  // written_point_count_: points [0, written_point_count_) of segment [written_seg_count_-1] are on disk.
+  size_t written_seg_count_ = 0;
+  size_t written_point_count_ = 0;
+
   mutable std::mutex mutex_;
-  mutable std::mutex file_mutex_;
 };

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -93,15 +93,23 @@ class PositionHistory {
     return current_attributes_;
   }
 
-  // Returns all segments (including the open tail) as a JSON array for client seeding.
-  // Format: [{"blades": bool, "points": [[x,y], ...]}, ...]
+  // Returns compacted segments and the raw pending buffer for client seeding.
+  // Format: {"segments": [{"blades": bool, "points": [[x,y], ...]}, ...],
+  //          "buffer":   [[x,y], ...]}
+  // The client should seed its own pipeline with both: segments replace history,
+  // buffer replaces the local raw buffer. Points arriving on position/json after
+  // this snapshot was taken are fed into the pipeline as usual.
   json getHistory() const {
     std::lock_guard<std::mutex> lk(mutex_);
-    json arr = json::array();
+    json segs = json::array();
     for (const auto& seg : history_segments_) {
-      arr.push_back(segmentToJson(seg));
+      segs.push_back(segmentToJson(seg));
     }
-    return arr;
+    json buf = json::array();
+    for (const auto& p : rel_buffer_) {
+      buf.push_back({p.x, p.y});
+    }
+    return {{"segments", segs}, {"buffer", buf}};
   }
 
  private:

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -41,6 +41,7 @@ class PositionHistory {
  public:
   struct TrackAttributes {
     bool blades = false;
+    bool idle = false;  // live-only; not persisted, not loaded
   };
 
   PositionHistory() = default;
@@ -417,4 +418,4 @@ class PositionHistory {
   mutable std::mutex mutex_;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PositionHistory::TrackAttributes, blades)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PositionHistory::TrackAttributes, blades, idle)

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -546,10 +546,16 @@ class PositionHistory {
       // session_id and blades must come from fresh STATE/BLADES events after boot;
       // restoring them would cause addPoint() to record while the mower is docked.
       current_attributes_.job_id = history_segments_.back().attributes.job_id;
-      written_seg_count_ = history_segments_.size();
-      written_point_count_ = history_segments_.back().points.size();
       file_path_ = latest.path.string();
       ROS_INFO_STREAM("PositionHistory: loaded existing file " << file_path_);
+
+      // Open a fresh segment (no bridge point) so post-boot points start a clean track.
+      Segment seg;
+      seg.attributes = current_attributes_;
+      history_segments_.push_back(std::move(seg));
+
+      written_seg_count_ = history_segments_.size() - 1;
+      written_point_count_ = 0;
     }
   }
 

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -90,8 +90,8 @@ class PositionHistory {
       if (job_changed) {
         compact(/*flush_all=*/true);
         writePending();
-        resetState();
         if (!current_attributes_.job_id.empty()) {
+          resetState();
           startNewSegment();
           writePending();
         }

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -554,7 +554,7 @@ class PositionHistory {
       history_segments_.push_back(std::move(seg));
 
       written_seg_count_ = history_segments_.size() - 1;
-      written_point_count_ = 0;
+      written_point_count_ = history_segments_[written_seg_count_ - 1].points.size();
     }
   }
 

--- a/src/lib/xbot_monitoring/src/PositionHistory.h
+++ b/src/lib/xbot_monitoring/src/PositionHistory.h
@@ -26,7 +26,7 @@ using json = nlohmann::ordered_json;
  * and a bridge vertex (last point of previous segment) is prepended so segments connect.
  *
  * Persistence (append-only JSONL, two record types):
- *   {"type":"new_segment","blades":true,"points":[[x,y],...]}
+ *   {"type":"new_segment","attributes":{"blades":true},"points":[[x,y],...]}
  *   {"type":"append_points","points":[[x,y],...]}
  *
  * writePending() is called ONLY from periodicFlush() (timer) and flush() (shutdown).
@@ -94,8 +94,8 @@ class PositionHistory {
   }
 
   // Returns compacted segments and the raw pending buffer for client seeding.
-  // Format: {"segments": [{"blades": bool, "points": [[x,y], ...]}, ...],
-  //          "buffer":   [[x,y], ...]}
+  // Format: {"segments": [{"attributes": {"blades": bool}, "points": [[x, y], ...]}, ...],
+  //          "buffer":   [[x, y], ...]}
   // The client should seed its own pipeline with both: segments replace history,
   // buffer replaces the local raw buffer. Points arriving on position/json after
   // this snapshot was taken are fed into the pipeline as usual.
@@ -373,7 +373,7 @@ class PositionHistory {
 
         if (type == "new_segment") {
           Segment seg;
-          seg.attributes.blades = j.at("blades").get<bool>();
+          seg.attributes.blades = j.at("attributes").at("blades").get<bool>();
           for (const auto& pt : j.at("points")) {
             seg.points.push_back({pt[0].get<double>(), pt[1].get<double>()});
           }
@@ -406,7 +406,7 @@ class PositionHistory {
     for (const auto& p : seg.points) {
       pts.push_back({p.x, p.y});
     }
-    return {{"blades", seg.attributes.blades}, {"points", pts}};
+    return {{"attributes", {{"blades", seg.attributes.blades}}}, {"points", pts}};
   }
 
   std::string file_path_;

--- a/src/lib/xbot_monitoring/src/capabilities.h
+++ b/src/lib/xbot_monitoring/src/capabilities.h
@@ -7,4 +7,5 @@ inline const nlohmann::ordered_json CAPABILITIES = {
     {"map:json", 1},
     {"mqtt:params", 1},
     {"events", 1},
+    {"position", 1},
 };

--- a/src/lib/xbot_monitoring/src/capabilities.h
+++ b/src/lib/xbot_monitoring/src/capabilities.h
@@ -6,4 +6,5 @@ inline const nlohmann::ordered_json CAPABILITIES = {
     {"rpc", 1},
     {"map:json", 1},
     {"mqtt:params", 1},
+    {"events", 1},
 };

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -571,13 +571,13 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
     std::nth_element(ys.begin(), ys.begin() + mid, ys.end());
     std::nth_element(hs.begin(), hs.begin() + mid, hs.end());
 
-    // {x, y, heading}, reuse the same json object to avoid allocation
-    static json j = json::object();
-    j["x"] = xs[mid];
-    j["y"] = ys[mid];
-    j["heading"] = hs[mid];
-    static const std::string position_topic = "position/json";
-    try_publish(position_topic, j.dump());
+    const json j = {
+        {"x", xs[mid]},
+        {"y", ys[mid]},
+        {"heading", hs[mid]},
+        {"attributes", position_history.getAttributes()},
+    };
+    try_publish("position/json", j.dump());
 
     if (!is_idle) {
       position_history.addPoint(xs[mid], ys[mid]);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -298,6 +298,12 @@ void try_publish(const std::string &topic, const std::string &data, bool retain 
     }
 }
 
+void publish_event(const std::string& type, json details = nullptr) {
+  const std::string payload_str = xbot_mqtt::buildEventPayload(type, details).dump();
+  try_publish(xbot_mqtt::EVENTS_TOPIC, payload_str);
+  event_history.add(payload_str);
+}
+
 void try_publish_binary(const std::string &topic, const void *data, size_t size, bool retain = false) {
     try {
         if (retain) {
@@ -879,6 +885,8 @@ int main(int argc, char **argv) {
 
     rpc_provider.init();
 
+    publish_event("BOOTED");
+
     ros::Rate sensor_check_rate(10.0);
 
     boost::regex topic_regex("/xbot_monitoring/sensors/.*/info");
@@ -928,6 +936,7 @@ int main(int argc, char **argv) {
         });
         sensor_check_rate.sleep();
     }
+    publish_event("SHUTDOWN");
     position_history.flush();
     return 0;
 }

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -555,7 +555,7 @@ void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
 void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
     try_publish(msg->topic, msg->payload, msg->retain);
 
-    if (msg->topic == "events/json") {
+    if (xbot_mqtt::isEvent(msg->topic)) {
         event_history.add(msg->payload);
         try {
             const std::string type = json::parse(msg->payload).at("type").get<std::string>();

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -32,6 +32,7 @@
 #include "xbot_msgs/SensorDataDouble.h"
 #include "xbot_msgs/SensorDataString.h"
 #include "xbot_msgs/SensorInfo.h"
+
 const double MQTT_POSITION_PUBLISH_INTERVAL = 0.150;
 const double POSITION_HISTORY_FLUSH_INTERVAL = 30.0;
 
@@ -157,8 +158,8 @@ PositionHistory position_history;
 // clang-format off
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
-return "pong";
-}),
+        return "pong";
+    }),
     RPC_METHOD("rpc.methods", {
         std::lock_guard<std::mutex> lk(registered_methods_mutex);
         json methods = json::array();
@@ -171,15 +172,15 @@ return "pong";
         return methods;
     }),
     RPC_METHOD("events.history", {
-if (params.is_object() && params.contains("date")) {
-return event_history.getAll(params["date"].get<std::string>());
-} else {
-return event_history.getAll();
-}
+        if (params.is_object() && params.contains("date")) {
+            return event_history.getAll(params["date"].get<std::string>());
+        } else {
+            return event_history.getAll();
+        }
     }),
     RPC_METHOD("events.history.list", {
-return event_history.listHistories();
-}),
+        return event_history.listHistories();
+    }),
     RPC_METHOD("events.history.delete", {
         if (params.is_object() && params.contains("date")) {
             return event_history.deleteHistory(params["date"].get<std::string>());
@@ -195,8 +196,8 @@ return event_history.listHistories();
         }
     }),
     RPC_METHOD("position.history.list", {
-return position_history.listHistories();
-}),
+        return position_history.listHistories();
+    }),
     RPC_METHOD("position.history.delete", {
         if (params.is_object() && params.contains("job_id")) {
             return position_history.deleteHistory(params["job_id"].get<std::string>());
@@ -832,8 +833,8 @@ int main(int argc, char **argv) {
         version_string = "UNKNOWN VERSION";
     }
 
-                    event_history.init();
-        position_history.init();
+    event_history.init();
+    position_history.init();
 
     external_mqtt_enable = paramNh.param("external_mqtt_enable", false);
     external_mqtt_topic_prefix = paramNh.param("external_mqtt_topic_prefix", std::string(""));

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -575,11 +575,13 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
       position_history.addPoint(xs[mid], ys[mid]);
     }
 
+auto attrs = position_history.getAttributes();
+    attrs.idle = is_idle;
     const json j = {
         {"x", xs[mid]},
         {"y", ys[mid]},
         {"heading", hs[mid]},
-        {"attributes", position_history.getAttributes()},
+        {"attributes", attrs},
     };
     try_publish("position/json", j.dump());
 }

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -154,10 +154,11 @@ bool has_map_overlay = false;
 EventHistory event_history;
 PositionHistory position_history;
 
+// clang-format off
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
-        return "pong";
-    }),
+return "pong";
+}),
     RPC_METHOD("rpc.methods", {
         std::lock_guard<std::mutex> lk(registered_methods_mutex);
         json methods = json::array();
@@ -170,7 +171,21 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
         return methods;
     }),
     RPC_METHOD("events.history", {
-        return event_history.getAll();
+if (params.is_object() && params.contains("date")) {
+return event_history.getAll(params["date"].get<std::string>());
+} else {
+return event_history.getAll();
+}
+    }),
+    RPC_METHOD("events.history.list", {
+return event_history.listHistories();
+}),
+    RPC_METHOD("events.history.delete", {
+        if (params.is_object() && params.contains("date")) {
+            return event_history.deleteHistory(params["date"].get<std::string>());
+        } else {
+            return event_history.deleteHistory(std::nullopt);
+        }
     }),
     RPC_METHOD("position.history", {
         if (params.is_object() && params.contains("job_id")) {
@@ -180,8 +195,8 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
         }
     }),
     RPC_METHOD("position.history.list", {
-        return position_history.listHistories();
-    }),
+return position_history.listHistories();
+}),
     RPC_METHOD("position.history.delete", {
         if (params.is_object() && params.contains("job_id")) {
             return position_history.deleteHistory(params["job_id"].get<std::string>());
@@ -190,6 +205,7 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
         }
     }),
 }});
+// clang-format on
 
 void setupMqttClient() {
     // setup mqtt client for app use
@@ -816,11 +832,8 @@ int main(int argc, char **argv) {
         version_string = "UNKNOWN VERSION";
     }
 
-    {
-        int event_history_max_size = paramNh.param("event_history_max_size", 100);
-        event_history.init(static_cast<size_t>(event_history_max_size));
+                    event_history.init();
         position_history.init();
-    }
 
     external_mqtt_enable = paramNh.param("external_mqtt_enable", false);
     external_mqtt_topic_prefix = paramNh.param("external_mqtt_topic_prefix", std::string(""));

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -571,6 +571,10 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
     std::nth_element(ys.begin(), ys.begin() + mid, ys.end());
     std::nth_element(hs.begin(), hs.begin() + mid, hs.end());
 
+    if (!is_idle) {
+      position_history.addPoint(xs[mid], ys[mid]);
+    }
+
     const json j = {
         {"x", xs[mid]},
         {"y", ys[mid]},
@@ -578,10 +582,6 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
         {"attributes", position_history.getAttributes()},
     };
     try_publish("position/json", j.dump());
-
-    if (!is_idle) {
-      position_history.addPoint(xs[mid], ys[mid]);
-    }
 }
 
 void position_history_flush_timer_callback(const ros::TimerEvent&) {

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -11,6 +11,7 @@
 #include "xbot_msgs/SensorDataString.h"
 #include "xbot_msgs/SensorDataDouble.h"
 #include "xbot_msgs/RobotState.h"
+#include "xbot_msgs/AbsolutePose.h"
 #include <mqtt/async_client.h>
 #include <nlohmann/json.hpp>
 #include <vector>
@@ -513,6 +514,16 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     try_publish_binary("robot_state/bson", bson.data(), bson.size());
 }
 
+void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
+    // Publish current position frequently for smoother UI updates.
+    // [x, y, heading] — reuse static json to avoid per-call heap allocation.
+    static json j = json::array({0.0, 0.0, 0.0});
+    j[0] = msg->pose.pose.position.x;
+    j[1] = msg->pose.pose.position.y;
+    j[2] = msg->vehicle_heading;
+    static const std::string position_topic = "position/json";
+    try_publish(position_topic, j.dump());
+}
 
 void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
     try_publish(msg->topic, msg->payload, msg->retain);
@@ -753,6 +764,7 @@ int main(int argc, char **argv) {
     ros::Subscriber robotStateSubscriber = n->subscribe("xbot_monitoring/robot_state", 10, robot_state_callback);
     ros::Subscriber mapSubscriber = n->subscribe("mower_map_service/json_map", 10, map_callback);
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
+    ros::Subscriber poseSubscriber = n->subscribe("/xbot_positioning/xb_pose", 10, pose_callback);
     ros::Subscriber mqttPublishSubscriber = n->subscribe("/xbot_monitoring/mqtt_publish", 50, mqtt_publish_callback);
 
     cmd_vel_pub = n->advertise<geometry_msgs::Twist>("xbot_monitoring/remote_cmd_vel", 1);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -29,6 +29,7 @@
 #include "xbot_mqtt/RegisterMethodsSrv.h"
 #include "capabilities.h"
 #include "EventHistory.h"
+#include "PositionHistory.h"
 
 using json = nlohmann::ordered_json;
 
@@ -147,6 +148,7 @@ bool has_map = false;
 bool has_map_overlay = false;
 
 EventHistory event_history;
+PositionHistory position_history;
 
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
@@ -165,6 +167,9 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     }),
     RPC_METHOD("events.history", {
         return event_history.getAll();
+    }),
+    RPC_METHOD("position.history", {
+        return position_history.getHistory();
     }),
 }});
 
@@ -521,6 +526,10 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
 }
 
 void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
+    position_history.addPoint(msg->pose.pose.position.x,
+        msg->pose.pose.position.y,
+        msg->header.stamp);
+
     // Publish current position frequently for smoother UI updates.
     // [x, y, heading] — reuse static json to avoid per-call heap allocation.
     static json j = json::array({0.0, 0.0, 0.0});
@@ -536,6 +545,12 @@ void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
 
     if (msg->topic == "events/json") {
         event_history.add(msg->payload);
+try {
+            const std::string type = json::parse(msg->payload).at("type").get<std::string>();
+            position_history.onEvent(type);
+        } catch (const json::exception& e) {
+            ROS_WARN_STREAM("mqtt_publish_callback: failed to parse event JSON: " << e.what());
+        }
     }
 }
 
@@ -753,6 +768,7 @@ int main(int argc, char **argv) {
     {
         int event_history_max_size = paramNh.param("event_history_max_size", 100);
         event_history.init(static_cast<size_t>(event_history_max_size));
+        position_history.init(static_cast<size_t>(event_history_max_size));
     }
 
     external_mqtt_enable = paramNh.param("external_mqtt_enable", false);
@@ -844,5 +860,6 @@ int main(int argc, char **argv) {
         });
         sensor_check_rate.sleep();
     }
+    position_history.flush();
     return 0;
 }

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -173,7 +173,21 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
         return event_history.getAll();
     }),
     RPC_METHOD("position.history", {
-        return position_history.getHistory();
+        if (params.is_object() && params.contains("job_id")) {
+            return position_history.getHistory(params["job_id"].get<std::string>());
+        } else {
+            return position_history.getHistory();
+        }
+    }),
+    RPC_METHOD("position.history.list", {
+        return position_history.listHistories();
+    }),
+    RPC_METHOD("position.history.delete", {
+        if (params.is_object() && params.contains("job_id")) {
+            return position_history.deleteHistory(params["job_id"].get<std::string>());
+        } else {
+            return position_history.deleteHistory(std::nullopt);
+        }
     }),
 }});
 

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -2,38 +2,36 @@
 // Created by Clemens Elflein on 22.11.22.
 // Copyright (c) 2022 Clemens Elflein. All rights reserved.
 //
-#include <filesystem>
-
-#include "ros/ros.h"
-#include <memory>
-#include <boost/regex.hpp>
-#include "xbot_msgs/SensorInfo.h"
-#include "xbot_msgs/SensorDataString.h"
-#include "xbot_msgs/SensorDataDouble.h"
-#include "xbot_msgs/RobotState.h"
-#include "xbot_msgs/AbsolutePose.h"
 #include <mqtt/async_client.h>
-#include <nlohmann/json.hpp>
-#include <atomic>
-#include <vector>
+
 #include <algorithm>
+#include <boost/regex.hpp>
+#include <filesystem>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "EventHistory.h"
+#include "PositionHistory.h"
+#include "capabilities.h"
 #include "geometry_msgs/Twist.h"
+#include "ros/ros.h"
 #include "std_msgs/String.h"
-#include "xbot_msgs/RegisterActionsSrv.h"
-#include "xbot_msgs/ActionInfo.h"
-#include "xbot_msgs/MapOverlay.h"
+#include "xbot_mqtt/RegisterMethodsSrv.h"
 #include "xbot_mqtt/RpcError.h"
 #include "xbot_mqtt/RpcRequest.h"
 #include "xbot_mqtt/RpcResponse.h"
 #include "xbot_mqtt/constants.h"
 #include "xbot_mqtt/provider.h"
 #include "xbot_mqtt/publish.h"
-#include "xbot_mqtt/RegisterMethodsSrv.h"
-#include "capabilities.h"
-#include "EventHistory.h"
-#include "PositionHistory.h"
-#include "mower_msgs/HighLevelStatus.h"
-
+#include "xbot_msgs/AbsolutePose.h"
+#include "xbot_msgs/ActionInfo.h"
+#include "xbot_msgs/MapOverlay.h"
+#include "xbot_msgs/RegisterActionsSrv.h"
+#include "xbot_msgs/RobotState.h"
+#include "xbot_msgs/SensorDataDouble.h"
+#include "xbot_msgs/SensorDataString.h"
+#include "xbot_msgs/SensorInfo.h"
 const double MQTT_POSITION_PUBLISH_INTERVAL = 0.150;
 const double POSITION_HISTORY_FLUSH_INTERVAL = 30.0;
 
@@ -155,7 +153,6 @@ bool has_map_overlay = false;
 
 EventHistory event_history;
 PositionHistory position_history;
-std::atomic<bool> is_idle{true};
 
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
@@ -503,13 +500,6 @@ void subscribe_to_sensor(std::string topic, std::vector<ros::Subscriber> &sensor
     }
 }
 
-void high_level_status_callback(const mower_msgs::HighLevelStatus::ConstPtr &msg) {
-    const uint8_t state = msg->state;
-    is_idle.store(state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL ||
-                      state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_IDLE,
-                  std::memory_order_relaxed);
-}
-
 void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     // Build a JSON and publish it
     json j;
@@ -571,12 +561,9 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
     std::nth_element(ys.begin(), ys.begin() + mid, ys.end());
     std::nth_element(hs.begin(), hs.begin() + mid, hs.end());
 
-    if (!is_idle) {
-      position_history.addPoint(xs[mid], ys[mid]);
-    }
+    position_history.addPoint(xs[mid], ys[mid]);
 
-auto attrs = position_history.getAttributes();
-    attrs.idle = is_idle;
+    const auto attrs = position_history.getAttributes();
     const json j = {
         {"x", xs[mid]},
         {"y", ys[mid]},
@@ -843,7 +830,6 @@ int main(int argc, char **argv) {
     ros::ServiceServer register_action_service = n->advertiseService("xbot/register_actions", registerActions);
 
     ros::Subscriber robotStateSubscriber = n->subscribe("xbot_monitoring/robot_state", 10, robot_state_callback);
-    ros::Subscriber highLevelStatusSubscriber = n->subscribe("mower_logic/current_state", 10, high_level_status_callback);
     ros::Subscriber mapSubscriber = n->subscribe("mower_map_service/json_map", 10, map_callback);
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
     ros::Subscriber poseSubscriber = n->subscribe("/xbot_positioning/xb_pose", 10, pose_callback);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -28,6 +28,7 @@
 #include "xbot_mqtt/publish.h"
 #include "xbot_mqtt/RegisterMethodsSrv.h"
 #include "capabilities.h"
+#include "EventHistory.h"
 
 using json = nlohmann::ordered_json;
 
@@ -145,6 +146,8 @@ std::mutex map_overlay_mutex;
 bool has_map = false;
 bool has_map_overlay = false;
 
+EventHistory event_history;
+
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
         return "pong";
@@ -159,6 +162,9 @@ xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
         }
         std::sort(methods.begin(), methods.end());
         return methods;
+    }),
+    RPC_METHOD("events.history", {
+        return event_history.getAll();
     }),
 }});
 
@@ -527,6 +533,10 @@ void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
 
 void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
     try_publish(msg->topic, msg->payload, msg->retain);
+
+    if (msg->topic == "events/json") {
+        event_history.add(msg->payload);
+    }
 }
 
 void publish_actions() {
@@ -738,6 +748,11 @@ int main(int argc, char **argv) {
     version_string = paramNh.param("software_version", std::string("UNKNOWN VERSION"));
     if(version_string.empty()) {
         version_string = "UNKNOWN VERSION";
+    }
+
+    {
+        int event_history_max_size = paramNh.param("event_history_max_size", 100);
+        event_history.init(static_cast<size_t>(event_history_max_size));
     }
 
     external_mqtt_enable = paramNh.param("external_mqtt_enable", false);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -24,6 +24,7 @@
 #include "xbot_mqtt/RpcResponse.h"
 #include "xbot_mqtt/constants.h"
 #include "xbot_mqtt/provider.h"
+#include "xbot_mqtt/publish.h"
 #include "xbot_mqtt/RegisterMethodsSrv.h"
 #include "capabilities.h"
 
@@ -224,7 +225,7 @@ void setupMqttClient() {
     }
 }
 
-void try_publish(std::string topic, std::string data, bool retain = false) {
+void try_publish(const std::string &topic, const std::string &data, bool retain = false) {
     try {
         if (retain) {
             // QOS 1 so that the data actually arrives at the client at least once.
@@ -250,7 +251,7 @@ void try_publish(std::string topic, std::string data, bool retain = false) {
     }
 }
 
-void try_publish_binary(std::string topic, const void *data, size_t size, bool retain = false) {
+void try_publish_binary(const std::string &topic, const void *data, size_t size, bool retain = false) {
     try {
         if (retain) {
             // QOS 1 so that the data actually arrives at the client at least once.
@@ -512,6 +513,11 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     try_publish_binary("robot_state/bson", bson.data(), bson.size());
 }
 
+
+void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
+    try_publish(msg->topic, msg->payload, msg->retain);
+}
+
 void publish_actions() {
     json actions = json::array();
     {
@@ -747,6 +753,7 @@ int main(int argc, char **argv) {
     ros::Subscriber robotStateSubscriber = n->subscribe("xbot_monitoring/robot_state", 10, robot_state_callback);
     ros::Subscriber mapSubscriber = n->subscribe("mower_map_service/json_map", 10, map_callback);
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
+    ros::Subscriber mqttPublishSubscriber = n->subscribe("/xbot_monitoring/mqtt_publish", 50, mqtt_publish_callback);
 
     cmd_vel_pub = n->advertise<geometry_msgs::Twist>("xbot_monitoring/remote_cmd_vel", 1);
     action_pub = n->advertise<std_msgs::String>("xbot/action", 1);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -611,7 +611,7 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
 }
 
 void position_history_flush_timer_callback(const ros::TimerEvent&) {
-  position_history.flush();
+  position_history.periodicFlush();
 }
 
 void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -30,6 +30,7 @@
 #include "capabilities.h"
 #include "EventHistory.h"
 #include "PositionHistory.h"
+#include "mower_msgs/HighLevelStatus.h"
 
 using json = nlohmann::ordered_json;
 
@@ -149,6 +150,7 @@ bool has_map_overlay = false;
 
 EventHistory event_history;
 PositionHistory position_history;
+uint8_t current_high_level_state = mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL;
 
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
@@ -496,6 +498,10 @@ void subscribe_to_sensor(std::string topic, std::vector<ros::Subscriber> &sensor
     }
 }
 
+void high_level_status_callback(const mower_msgs::HighLevelStatus::ConstPtr &msg) {
+    current_high_level_state = msg->state;
+}
+
 void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     // Build a JSON and publish it
     json j;
@@ -526,9 +532,15 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
 }
 
 void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
-    position_history.addPoint(msg->pose.pose.position.x,
-        msg->pose.pose.position.y,
-        msg->header.stamp);
+    const bool is_idle =
+        current_high_level_state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL ||
+        current_high_level_state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_IDLE;
+
+    if (!is_idle) {
+        position_history.addPoint(msg->pose.pose.position.x,
+                                msg->pose.pose.position.y,
+                                msg->header.stamp);
+    }
 
     // Publish current position frequently for smoother UI updates.
     // [x, y, heading] — reuse static json to avoid per-call heap allocation.
@@ -545,7 +557,7 @@ void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
 
     if (msg->topic == "events/json") {
         event_history.add(msg->payload);
-try {
+        try {
             const std::string type = json::parse(msg->payload).at("type").get<std::string>();
             position_history.onEvent(type);
         } catch (const json::exception& e) {
@@ -793,6 +805,7 @@ int main(int argc, char **argv) {
     ros::ServiceServer register_action_service = n->advertiseService("xbot/register_actions", registerActions);
 
     ros::Subscriber robotStateSubscriber = n->subscribe("xbot_monitoring/robot_state", 10, robot_state_callback);
+    ros::Subscriber highLevelStatusSubscriber = n->subscribe("mower_logic/current_state", 10, high_level_status_callback);
     ros::Subscriber mapSubscriber = n->subscribe("mower_map_service/json_map", 10, map_callback);
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
     ros::Subscriber poseSubscriber = n->subscribe("/xbot_positioning/xb_pose", 10, pose_callback);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -571,11 +571,11 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
     std::nth_element(ys.begin(), ys.begin() + mid, ys.end());
     std::nth_element(hs.begin(), hs.begin() + mid, hs.end());
 
-    // [x, y, heading], reuse the same json object to avoid allocation
-    static json j = json::array({0.0, 0.0, 0.0});
-    j[0] = xs[mid];
-    j[1] = ys[mid];
-    j[2] = hs[mid];
+    // {x, y, heading}, reuse the same json object to avoid allocation
+    static json j = json::object();
+    j["x"] = xs[mid];
+    j["y"] = ys[mid];
+    j["heading"] = hs[mid];
     static const std::string position_topic = "position/json";
     try_publish(position_topic, j.dump());
 

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -15,6 +15,7 @@
 #include <mqtt/async_client.h>
 #include <nlohmann/json.hpp>
 #include <vector>
+#include <algorithm>
 #include "geometry_msgs/Twist.h"
 #include "std_msgs/String.h"
 #include "xbot_msgs/RegisterActionsSrv.h"
@@ -31,6 +32,8 @@
 #include "EventHistory.h"
 #include "PositionHistory.h"
 #include "mower_msgs/HighLevelStatus.h"
+
+const double MQTT_POSITION_PUBLISH_INTERVAL = 0.150;
 
 using json = nlohmann::ordered_json;
 
@@ -531,6 +534,12 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
     try_publish_binary("robot_state/bson", bson.data(), bson.size());
 }
 
+struct PoseSample {
+    double x, y, heading;
+};
+std::vector<PoseSample> pose_buffer;
+std::mutex pose_buffer_mutex;
+
 void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
     const bool is_idle =
         current_high_level_state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL ||
@@ -542,12 +551,38 @@ void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
                                 msg->header.stamp);
     }
 
-    // Publish current position frequently for smoother UI updates.
-    // [x, y, heading] — reuse static json to avoid per-call heap allocation.
+    std::lock_guard<std::mutex> lk(pose_buffer_mutex);
+    pose_buffer.push_back({msg->pose.pose.position.x,
+                           msg->pose.pose.position.y,
+                           msg->vehicle_heading});
+}
+
+void pose_publish_timer_callback(const ros::TimerEvent&) {
+    std::vector<PoseSample> buf;
+    {
+        std::lock_guard<std::mutex> lk(pose_buffer_mutex);
+        if (pose_buffer.empty()) return;
+        buf.swap(pose_buffer);
+    }
+
+    const size_t n = buf.size();
+    const size_t mid = n / 2;
+
+    std::vector<double> xs(n), ys(n), hs(n);
+    for (size_t i = 0; i < n; ++i) {
+        xs[i] = buf[i].x;
+        ys[i] = buf[i].y;
+        hs[i] = buf[i].heading;
+    }
+    std::nth_element(xs.begin(), xs.begin() + mid, xs.end());
+    std::nth_element(ys.begin(), ys.begin() + mid, ys.end());
+    std::nth_element(hs.begin(), hs.begin() + mid, hs.end());
+
+    // [x, y, heading], reuse the same json object to avoid allocation
     static json j = json::array({0.0, 0.0, 0.0});
-    j[0] = msg->pose.pose.position.x;
-    j[1] = msg->pose.pose.position.y;
-    j[2] = msg->vehicle_heading;
+    j[0] = xs[mid];
+    j[1] = ys[mid];
+    j[2] = hs[mid];
     static const std::string position_topic = "position/json";
     try_publish(position_topic, j.dump());
 }
@@ -809,6 +844,7 @@ int main(int argc, char **argv) {
     ros::Subscriber mapSubscriber = n->subscribe("mower_map_service/json_map", 10, map_callback);
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
     ros::Subscriber poseSubscriber = n->subscribe("/xbot_positioning/xb_pose", 10, pose_callback);
+    ros::Timer posePublishTimer = n->createTimer(ros::Duration(MQTT_POSITION_PUBLISH_INTERVAL), pose_publish_timer_callback);
     ros::Subscriber mqttPublishSubscriber = n->subscribe("/xbot_monitoring/mqtt_publish", 50, mqtt_publish_callback);
 
     cmd_vel_pub = n->advertise<geometry_msgs::Twist>("xbot_monitoring/remote_cmd_vel", 1);

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -14,6 +14,7 @@
 #include "xbot_msgs/AbsolutePose.h"
 #include <mqtt/async_client.h>
 #include <nlohmann/json.hpp>
+#include <atomic>
 #include <vector>
 #include <algorithm>
 #include "geometry_msgs/Twist.h"
@@ -34,6 +35,7 @@
 #include "mower_msgs/HighLevelStatus.h"
 
 const double MQTT_POSITION_PUBLISH_INTERVAL = 0.150;
+const double POSITION_HISTORY_FLUSH_INTERVAL = 30.0;
 
 using json = nlohmann::ordered_json;
 
@@ -153,7 +155,7 @@ bool has_map_overlay = false;
 
 EventHistory event_history;
 PositionHistory position_history;
-uint8_t current_high_level_state = mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL;
+std::atomic<bool> is_idle{true};
 
 xbot_mqtt::RpcProvider rpc_provider("xbot_monitoring", {{
     RPC_METHOD("rpc.ping", {
@@ -502,7 +504,10 @@ void subscribe_to_sensor(std::string topic, std::vector<ros::Subscriber> &sensor
 }
 
 void high_level_status_callback(const mower_msgs::HighLevelStatus::ConstPtr &msg) {
-    current_high_level_state = msg->state;
+    const uint8_t state = msg->state;
+    is_idle.store(state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL ||
+                      state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_IDLE,
+                  std::memory_order_relaxed);
 }
 
 void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
@@ -541,20 +546,8 @@ std::vector<PoseSample> pose_buffer;
 std::mutex pose_buffer_mutex;
 
 void pose_callback(const xbot_msgs::AbsolutePose::ConstPtr& msg) {
-    const bool is_idle =
-        current_high_level_state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL ||
-        current_high_level_state == mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_IDLE;
-
-    if (!is_idle) {
-        position_history.addPoint(msg->pose.pose.position.x,
-                                msg->pose.pose.position.y,
-                                msg->header.stamp);
-    }
-
-    std::lock_guard<std::mutex> lk(pose_buffer_mutex);
-    pose_buffer.push_back({msg->pose.pose.position.x,
-                           msg->pose.pose.position.y,
-                           msg->vehicle_heading});
+  std::lock_guard<std::mutex> lk(pose_buffer_mutex);
+  pose_buffer.push_back({msg->pose.pose.position.x, msg->pose.pose.position.y, msg->vehicle_heading});
 }
 
 void pose_publish_timer_callback(const ros::TimerEvent&) {
@@ -585,6 +578,14 @@ void pose_publish_timer_callback(const ros::TimerEvent&) {
     j[2] = hs[mid];
     static const std::string position_topic = "position/json";
     try_publish(position_topic, j.dump());
+
+    if (!is_idle) {
+      position_history.addPoint(xs[mid], ys[mid]);
+    }
+}
+
+void position_history_flush_timer_callback(const ros::TimerEvent&) {
+  position_history.flush();
 }
 
 void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
@@ -593,8 +594,8 @@ void mqtt_publish_callback(const xbot_mqtt::MqttPublish::ConstPtr& msg) {
     if (xbot_mqtt::isEvent(msg->topic)) {
         event_history.add(msg->payload);
         try {
-            const std::string type = json::parse(msg->payload).at("type").get<std::string>();
-            position_history.onEvent(type);
+          const json event = json::parse(msg->payload);
+          position_history.onEvent(event);
         } catch (const json::exception& e) {
             ROS_WARN_STREAM("mqtt_publish_callback: failed to parse event JSON: " << e.what());
         }
@@ -815,7 +816,7 @@ int main(int argc, char **argv) {
     {
         int event_history_max_size = paramNh.param("event_history_max_size", 100);
         event_history.init(static_cast<size_t>(event_history_max_size));
-        position_history.init(static_cast<size_t>(event_history_max_size));
+        position_history.init();
     }
 
     external_mqtt_enable = paramNh.param("external_mqtt_enable", false);
@@ -845,6 +846,8 @@ int main(int argc, char **argv) {
     ros::Subscriber mapOverlaySubscriber = n->subscribe("xbot_monitoring/map_overlay", 10, map_overlay_callback);
     ros::Subscriber poseSubscriber = n->subscribe("/xbot_positioning/xb_pose", 10, pose_callback);
     ros::Timer posePublishTimer = n->createTimer(ros::Duration(MQTT_POSITION_PUBLISH_INTERVAL), pose_publish_timer_callback);
+    ros::Timer positionHistoryFlushTimer =
+        n->createTimer(ros::Duration(POSITION_HISTORY_FLUSH_INTERVAL), position_history_flush_timer_callback);
     ros::Subscriber mqttPublishSubscriber = n->subscribe("/xbot_monitoring/mqtt_publish", 50, mqtt_publish_callback);
 
     cmd_vel_pub = n->advertise<geometry_msgs::Twist>("xbot_monitoring/remote_cmd_vel", 1);

--- a/src/lib/xbot_mqtt/CMakeLists.txt
+++ b/src/lib/xbot_mqtt/CMakeLists.txt
@@ -12,6 +12,7 @@ add_message_files(
         RpcRequest.msg
         RpcResponse.msg
         RpcError.msg
+        MqttPublish.msg
 )
 
 add_service_files(

--- a/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
+++ b/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
@@ -17,6 +17,8 @@
 
 namespace xbot_mqtt {
 
+static const std::string EVENTS_TOPIC = "events/json";
+
 // Same algorithm as mower_map_service generateNanoId()
 inline std::string generateNanoId(size_t length = 32) {
     static const char alphabet[] =
@@ -40,7 +42,7 @@ inline void publish(ros::Publisher& pub,
     pub.publish(msg);
 }
 
-// Convenience wrapper for events: hardcodes topic = "events/json".
+// Convenience wrapper to publish events.
 // Always injects "id" (NanoId), "t" (current ROS time, float seconds), and "type".
 // Optional details object is merged into the payload for event-specific fields.
 inline void publishEvent(ros::Publisher& pub,
@@ -55,7 +57,11 @@ inline void publishEvent(ros::Publisher& pub,
     if (details.is_object()) {
         payload.update(details);
     }
-    publish(pub, "events/json", payload, retain);
+    publish(pub, EVENTS_TOPIC, payload, retain);
+}
+
+inline bool isEvent(const std::string& topic) {
+    return topic == EVENTS_TOPIC;
 }
 
 }  // namespace xbot_mqtt

--- a/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
+++ b/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <algorithm>
+#include <random>
+#include <string>
+
+#include <ros/ros.h>
+#include <nlohmann/json.hpp>
+#include <xbot_mqtt/MqttPublish.h>
+
+// Declares and advertises the MQTT publish publisher in the enclosing scope.
+// Usage (once in main()): MQTT_PUBLISHER(*n);
+// Creates variable: ros::Publisher mqtt_publish_pub
+#define MQTT_PUBLISHER(nh) \
+    ros::Publisher mqtt_publish_pub = \
+        (nh).advertise<xbot_mqtt::MqttPublish>("/xbot_monitoring/mqtt_publish", 10)
+
+namespace xbot_mqtt {
+
+// Same algorithm as mower_map_service generateNanoId()
+inline std::string generateNanoId(size_t length = 32) {
+    static const char alphabet[] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    thread_local std::mt19937 rng{std::random_device{}()};
+    thread_local std::uniform_int_distribution<> dist(0, sizeof(alphabet) - 2);
+    std::string id(length, '\0');
+    std::generate_n(id.begin(), length, [&]() { return alphabet[dist(rng)]; });
+    return id;
+}
+
+// Generic publish to any MQTT topic. Payload is forwarded as-is.
+inline void publish(ros::Publisher& pub,
+                    const std::string& mqtt_topic,
+                    const nlohmann::json& payload_json,
+                    bool retain = false) {
+    xbot_mqtt::MqttPublish msg;
+    msg.topic   = mqtt_topic;
+    msg.payload = payload_json.dump();
+    msg.retain  = retain;
+    pub.publish(msg);
+}
+
+// Convenience wrapper for events: hardcodes topic = "events/json".
+// Always injects "id" (NanoId), "t" (current ROS time, float seconds), and "type".
+// Optional details object is merged into the payload for event-specific fields.
+inline void publishEvent(ros::Publisher& pub,
+                         const std::string& type,
+                         nlohmann::json details = nullptr,
+                         bool retain = false) {
+    nlohmann::json payload = {
+        {"id",   generateNanoId()},
+        {"t",    ros::Time::now().toSec()},
+        {"type", type},
+    };
+    if (details.is_object()) {
+        payload.update(details);
+    }
+    publish(pub, "events/json", payload, retain);
+}
+
+}  // namespace xbot_mqtt

--- a/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
+++ b/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
@@ -49,14 +49,10 @@ inline void publishEvent(ros::Publisher& pub,
                          const std::string& type,
                          nlohmann::json details = nullptr,
                          bool retain = false) {
-    nlohmann::json payload = {
-        {"id",   generateNanoId()},
-        {"t",    ros::Time::now().toSec()},
-        {"type", type},
-    };
-    if (details.is_object()) {
-        payload.update(details);
-    }
+    nlohmann::json payload = details.is_object() ? details : nlohmann::json::object();
+    payload["id"]   = generateNanoId();
+    payload["t"]    = ros::Time::now().toSec();
+    payload["type"] = type;
     publish(pub, EVENTS_TOPIC, payload, retain);
 }
 

--- a/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
+++ b/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
@@ -8,6 +8,8 @@
 #include <nlohmann/json.hpp>
 #include <xbot_mqtt/MqttPublish.h>
 
+using json = nlohmann::ordered_json;
+
 // Declares and advertises the MQTT publish publisher in the enclosing scope.
 // Usage (once in main()): MQTT_PUBLISHER(*n);
 // Creates variable: ros::Publisher mqtt_publish_pub
@@ -31,29 +33,24 @@ inline std::string generateNanoId(size_t length = 32) {
 }
 
 // Generic publish to any MQTT topic. Payload is forwarded as-is.
-inline void publish(ros::Publisher& pub,
-                    const std::string& mqtt_topic,
-                    const nlohmann::json& payload_json,
-                    bool retain = false) {
-    xbot_mqtt::MqttPublish msg;
-    msg.topic   = mqtt_topic;
-    msg.payload = payload_json.dump();
-    msg.retain  = retain;
-    pub.publish(msg);
+inline void publish(ros::Publisher& pub, const std::string& mqtt_topic, const json& payload_json, bool retain = false) {
+  xbot_mqtt::MqttPublish msg;
+  msg.topic = mqtt_topic;
+  msg.payload = payload_json.dump();
+  msg.retain = retain;
+  pub.publish(msg);
 }
 
 // Convenience wrapper to publish events.
 // Always injects "id" (NanoId), "t" (current ROS time, float seconds), and "type".
 // Optional details object is merged into the payload for event-specific fields.
-inline void publishEvent(ros::Publisher& pub,
-                         const std::string& type,
-                         nlohmann::json details = nullptr,
-                         bool retain = false) {
-    nlohmann::json payload = details.is_object() ? details : nlohmann::json::object();
-    payload["id"]   = generateNanoId();
-    payload["t"]    = ros::Time::now().toSec();
-    payload["type"] = type;
-    publish(pub, EVENTS_TOPIC, payload, retain);
+inline void publishEvent(ros::Publisher& pub, const std::string& type, json details = nullptr, bool retain = false) {
+  json payload = json::object();
+  payload["id"] = generateNanoId();
+  payload["t"] = ros::Time::now().toSec();
+  payload["type"] = type;
+  if (details.is_object()) payload.update(details);
+  publish(pub, EVENTS_TOPIC, payload, retain);
 }
 
 inline bool isEvent(const std::string& topic) {

--- a/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
+++ b/src/lib/xbot_mqtt/include/xbot_mqtt/publish.h
@@ -41,16 +41,21 @@ inline void publish(ros::Publisher& pub, const std::string& mqtt_topic, const js
   pub.publish(msg);
 }
 
-// Convenience wrapper to publish events.
+// Builds an event payload JSON object.
 // Always injects "id" (NanoId), "t" (current ROS time, float seconds), and "type".
 // Optional details object is merged into the payload for event-specific fields.
-inline void publishEvent(ros::Publisher& pub, const std::string& type, json details = nullptr, bool retain = false) {
+inline json buildEventPayload(const std::string& type, json details = nullptr) {
   json payload = json::object();
   payload["id"] = generateNanoId();
   payload["t"] = ros::Time::now().toSec();
   payload["type"] = type;
   if (details.is_object()) payload.update(details);
-  publish(pub, EVENTS_TOPIC, payload, retain);
+  return payload;
+}
+
+// Convenience wrapper to publish events via ROS.
+inline void publishEvent(ros::Publisher& pub, const std::string& type, json details = nullptr, bool retain = false) {
+  publish(pub, EVENTS_TOPIC, buildEventPayload(type, details), retain);
 }
 
 inline bool isEvent(const std::string& topic) {

--- a/src/lib/xbot_mqtt/msg/MqttPublish.msg
+++ b/src/lib/xbot_mqtt/msg/MqttPublish.msg
@@ -1,0 +1,3 @@
+string topic      # MQTT topic, e.g. "events/json"
+string payload    # pre-encoded JSON string
+bool retain

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -131,6 +131,7 @@ int main(int argc, char** argv) {
   ros::NodeHandle paramNh("/ll");
 
   highLevelClient = n.serviceClient<mower_msgs::HighLevelControlSrv>("mower_service/high_level_control");
+  action_pub = n.advertise<std_msgs::String>("xbot/action", 1);
 
   std::string bind_ip = "0.0.0.0";
   paramNh.getParam("bind_ip", bind_ip);
@@ -289,7 +290,6 @@ int main(int argc, char** argv) {
   // ros::Subscriber high_level_status_sub = n.subscribe("/mower_logic/current_state", 0, highLevelStatusReceived);
   ros::Timer publish_timer = n.createTimer(ros::Duration(0.5), sendEmergencyHeartbeatTimerTask);
   ros::Timer publish_timer_2 = n.createTimer(ros::Duration(5.0), sendMowerEnabledTimerTask);
-  action_pub = n.advertise<std_msgs::String>("xbot/action", 1);
   ros::Subscriber action_sub = n.subscribe("xbot/action", 0, actionReceived, ros::TransportHints().tcpNoDelay(true));
 
   ROS_INFO("All mower_comms_v2 services started");

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -66,21 +66,15 @@ std::unique_ptr<HighLevelServiceInterface> high_level_service = nullptr;
 xbot::serviceif::Context ctx{};
 
 bool setEmergencyStop(mower_msgs::EmergencyStopSrvRequest& req, mower_msgs::EmergencyStopSrvResponse& res) {
-  // This should never be the case, also this is no race condition, because callback will only be called
-  // after initialization whereas the service is created during intialization
-  if (!emergency_service) return false;
-
   emergency_service->SetHighLevelEmergency(req.emergency);
   return true;
 }
 
 void velReceived(const geometry_msgs::Twist::ConstPtr& msg) {
-  if (!diff_drive_service) return;
   diff_drive_service->SendTwist(msg);
 }
 
 void rtcmReceived(const rtcm_msgs::Message& msg) {
-  if (!gps_service) return;
   static std::vector<uint8_t> rtcm_buffer{};
   static ros::Time last_time_sent{0};
   ros::Time now = ros::Time::now();
@@ -137,16 +131,6 @@ int main(int argc, char** argv) {
   ros::NodeHandle paramNh("/ll");
 
   highLevelClient = n.serviceClient<mower_msgs::HighLevelControlSrv>("mower_service/high_level_control");
-
-  ros::ServiceServer mow_service = n.advertiseService("ll/_service/mow_enabled", setMowEnabled);
-  ros::ServiceServer ros_emergency_service = n.advertiseService("ll/_service/emergency", setEmergencyStop);
-  ros::Subscriber cmd_vel_sub = n.subscribe("ll/cmd_vel", 0, velReceived, ros::TransportHints().tcpNoDelay(true));
-  ros::Subscriber rtcm_sub = n.subscribe("ll/position/gps/rtcm", 0, rtcmReceived);
-  // ros::Subscriber high_level_status_sub = n.subscribe("/mower_logic/current_state", 0, highLevelStatusReceived);
-  ros::Timer publish_timer = n.createTimer(ros::Duration(0.5), sendEmergencyHeartbeatTimerTask);
-  ros::Timer publish_timer_2 = n.createTimer(ros::Duration(5.0), sendMowerEnabledTimerTask);
-  action_pub = n.advertise<std_msgs::String>("xbot/action", 1);
-  ros::Subscriber action_sub = n.subscribe("xbot/action", 0, actionReceived, ros::TransportHints().tcpNoDelay(true));
 
   std::string bind_ip = "0.0.0.0";
   paramNh.getParam("bind_ip", bind_ip);
@@ -295,6 +279,20 @@ int main(int argc, char** argv) {
   // HighLevel service
   high_level_service = std::make_unique<HighLevelServiceInterface>(xbot::service_ids::HIGH_LEVEL, ctx);
   high_level_service->Start();
+
+  // All subscriptions, timers and service servers are registered after all service interfaces are
+  // fully constructed, so callbacks can never fire on null pointers.
+  ros::ServiceServer mow_service = n.advertiseService("ll/_service/mow_enabled", setMowEnabled);
+  ros::ServiceServer ros_emergency_service = n.advertiseService("ll/_service/emergency", setEmergencyStop);
+  ros::Subscriber cmd_vel_sub = n.subscribe("ll/cmd_vel", 0, velReceived, ros::TransportHints().tcpNoDelay(true));
+  ros::Subscriber rtcm_sub = n.subscribe("ll/position/gps/rtcm", 0, rtcmReceived);
+  // ros::Subscriber high_level_status_sub = n.subscribe("/mower_logic/current_state", 0, highLevelStatusReceived);
+  ros::Timer publish_timer = n.createTimer(ros::Duration(0.5), sendEmergencyHeartbeatTimerTask);
+  ros::Timer publish_timer_2 = n.createTimer(ros::Duration(5.0), sendMowerEnabledTimerTask);
+  action_pub = n.advertise<std_msgs::String>("xbot/action", 1);
+  ros::Subscriber action_sub = n.subscribe("xbot/action", 0, actionReceived, ros::TransportHints().tcpNoDelay(true));
+
+  ROS_INFO("All mower_comms_v2 services started");
 
   ros::spin();
   xbot::serviceif::Stop();

--- a/src/mower_logic/CMakeLists.txt
+++ b/src/mower_logic/CMakeLists.txt
@@ -24,10 +24,13 @@ find_package(catkin REQUIRED COMPONENTS
         robot_localization
         xbot_msgs
         xbot_positioning
+        xbot_mqtt
 )
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CRYPTOPP REQUIRED libcrypto++)
+
+add_subdirectory(../lib/json json EXCLUDE_FROM_ALL)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -135,6 +138,7 @@ include_directories(
         include
         ${catkin_INCLUDE_DIRS}
         ${CRYPTOPP_INCLUDE_DIRS}
+        ${xbot_mqtt_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -184,7 +188,7 @@ add_executable(mower_logic
         src/mower_logic/behaviors/AreaRecordingBehavior.cpp
 )
 add_dependencies(mower_logic ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(mower_logic ${catkin_LIBRARIES} ${CRYPTOPP_LIBRARIES})
+target_link_libraries(mower_logic ${catkin_LIBRARIES} ${CRYPTOPP_LIBRARIES} nlohmann_json::nlohmann_json)
 
 add_executable(monitoring src/monitoring/monitoring.cpp)
 add_dependencies(monitoring ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/src/mower_logic/msg/CheckPoint.msg
+++ b/src/mower_logic/msg/CheckPoint.msg
@@ -1,3 +1,4 @@
+string job_id
 int32 currentMowingPath
 int32 currentMowingArea
 int32 currentMowingPathIndex

--- a/src/mower_logic/package.xml
+++ b/src/mower_logic/package.xml
@@ -24,6 +24,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>xbot_msgs</build_depend>
+  <depend>xbot_mqtt</depend>
   <build_depend>crypto++</build_depend>
   <depend>xbot_positioning</depend>
   <build_export_depend>dynamic_reconfigure</build_export_depend>

--- a/src/mower_logic/src/mower_logic/behaviors/Behavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/Behavior.h
@@ -19,6 +19,8 @@
 
 #include <atomic>
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
 
 #include "mower_logic/MowerLogicConfig.h"
 #include "mower_msgs/HighLevelStatus.h"
@@ -32,6 +34,9 @@ struct sSharedState {
   // True, if the semiautomatic task is still in progress
   bool active_semiautomatic_task;
 };
+
+using json = nlohmann::ordered_json;
+extern void publishMowerEvent(const std::string& type, json details = json::object());
 
 /**
  * Behavior definition

--- a/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
@@ -163,6 +163,7 @@ bool DockingBehavior::dock_straight() {
           mbfClientExePath->cancelGoal();
           stopMoving();
           dockingSuccess = true;
+          publishMowerEvent("DOCKED");
           waitingForResult = false;
         }
         break;
@@ -173,6 +174,7 @@ bool DockingBehavior::dock_straight() {
           mbfClientExePath->cancelGoal();
           dockingSuccess = true;
           stopMoving();
+          publishMowerEvent("DOCKED");
         }
         waitingForResult = false;
         break;
@@ -199,6 +201,7 @@ Behavior* DockingBehavior::execute() {
   if (getPower().charge_voltage > 5.0 || getPower().charge_voltage_adc > 5.0) {
     ROS_INFO_STREAM("Already inside docking station, going directly to idle.");
     stopMoving();
+    publishMowerEvent("DOCKED");
     return &IdleBehavior::DOCKED_INSTANCE;
   }
 
@@ -227,10 +230,12 @@ Behavior* DockingBehavior::execute() {
     retryCount++;
     if (retryCount <= config.docking_retry_count) {
       ROS_ERROR("Retrying docking approach");
+      publishMowerEvent("DOCKING_RETRY", json{{"reason", "approach_failed"}, {"attempts", retryCount}});
       return &DockingBehavior::INSTANCE;
     }
 
     ROS_ERROR("Giving up on docking");
+    publishMowerEvent("DOCKING_FAILED", json{{"reason", "approach_failed"}, {"attempts", retryCount}});
     return &IdleBehavior::INSTANCE;
   }
 
@@ -257,12 +262,14 @@ Behavior* DockingBehavior::execute() {
     retryCount++;
     if (retryCount <= config.docking_retry_count && !aborted) {
       ROS_ERROR_STREAM("Retrying docking. Try " << retryCount << " / " << config.docking_retry_count);
+      publishMowerEvent("DOCKING_RETRY", json{{"reason", "dock_failed"}, {"attempts", retryCount}});
       return &UndockingBehavior::RETRY_INSTANCE;
     }
 
     ROS_ERROR("Giving up on docking");
     // Reset retryCount
     reset();
+    publishMowerEvent("DOCKING_FAILED", json{{"reason", "dock_failed"}, {"attempts", retryCount}});
     return &IdleBehavior::INSTANCE;
   }
 

--- a/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/DockingBehavior.cpp
@@ -267,9 +267,9 @@ Behavior* DockingBehavior::execute() {
     }
 
     ROS_ERROR("Giving up on docking");
+    publishMowerEvent("DOCKING_FAILED", json{{"reason", "dock_failed"}, {"attempts", retryCount}});
     // Reset retryCount
     reset();
-    publishMowerEvent("DOCKING_FAILED", json{{"reason", "dock_failed"}, {"attempts", retryCount}});
     return &IdleBehavior::INSTANCE;
   }
 

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -71,6 +71,7 @@ Behavior* IdleBehavior::execute() {
   docking_pose_stamped.header.stamp = ros::Time::now();
 
   ros::Rate r(25);
+  bool seen_not_charging = false;
   while (ros::ok()) {
     stopMoving();
     stopBlade();
@@ -96,6 +97,15 @@ Behavior* IdleBehavior::execute() {
     const bool mower_ready = last_battery_v > last_power_config.battery_full_voltage &&
                              last_status.mower_motor_temperature < last_config.motor_cold_temperature &&
                              !last_config.manual_pause_mowing && !rain_delay;
+
+    const bool currently_charging = last_charge_v > 10.0;
+    if (!currently_charging) {
+      seen_not_charging = true;
+    }
+    if (mower_ready && currently_charging && seen_not_charging) {
+      publishMowerEvent("FULLY_CHARGED", json{{"battery_voltage", last_battery_v}});
+      seen_not_charging = false;
+    }
 
     if (manual_start_mowing || ((automatic_mode || active_semiautomatic_task) && mower_ready)) {
       // set the robot's position to the dock if we're actually docked

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -43,6 +43,9 @@ extern void setConfig(mower_logic::MowerLogicConfig);
 
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
 
+extern std::string current_job_id;
+extern bool current_job_finished;
+
 MowingBehavior MowingBehavior::INSTANCE;
 
 std::string MowingBehavior::state_name() {
@@ -112,6 +115,7 @@ void MowingBehavior::exit() {
 }
 
 void MowingBehavior::reset() {
+  current_job_finished = true;
   currentMowingPaths.clear();
   currentMowingArea = 0;
   currentMowingPath = 0;
@@ -761,6 +765,7 @@ void MowingBehavior::handle_action(std::string action) {
 void MowingBehavior::checkpoint() {
   rosbag::Bag bag;
   mower_logic::CheckPoint cp;
+  cp.job_id = current_job_id;
   cp.currentMowingPath = currentMowingPath;
   cp.currentMowingArea = currentMowingArea;
   cp.currentMowingPathIndex = currentMowingPathIndex;
@@ -792,9 +797,10 @@ bool MowingBehavior::restore_checkpoint() {
       if (cp) {
         ROS_INFO_STREAM("Restoring checkpoint for plan ("
                         << cp->currentMowingPlanDigest << ")"
-                        << " area: " << cp->currentMowingArea << " path: " << cp->currentMowingPath
-                        << " index: " << cp->currentMowingPathIndex
+                        << " job: " << cp->job_id << " area: " << cp->currentMowingArea
+                        << " path: " << cp->currentMowingPath << " index: " << cp->currentMowingPathIndex
                         << " angle increment sum: " << cp->currentMowingAngleIncrementSum);
+        current_job_id = cp->job_id;
         currentMowingPath = cp->currentMowingPath;
         currentMowingArea = cp->currentMowingArea;
         currentMowingPathIndex = cp->currentMowingPathIndex;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -159,6 +159,9 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
     return false;
   }
 
+  currentMowingAreaId = mapSrv.response.area.id;
+  currentMowingAreaName = mapSrv.response.area.name;
+
   if (!mapSrv.response.area.active) {
     ROS_INFO_STREAM("MowingBehavior: Skipping inactive mowing area");
     return true;
@@ -679,8 +682,16 @@ uint8_t MowingBehavior::get_state() {
   return mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_AUTONOMOUS;
 }
 
-int16_t MowingBehavior::get_current_area() {
+int16_t MowingBehavior::get_current_area() const {
   return currentMowingArea;
+}
+
+std::string MowingBehavior::get_current_area_id() const {
+  return currentMowingAreaId;
+}
+
+std::string MowingBehavior::get_current_area_name() const {
+  return currentMowingAreaName;
 }
 
 int16_t MowingBehavior::get_current_path() {

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -115,6 +115,7 @@ void MowingBehavior::exit() {
 }
 
 void MowingBehavior::reset() {
+  publishMowerEvent("JOB_COMPLETE");
   current_job_finished = true;
   currentMowingPaths.clear();
   currentMowingArea = 0;
@@ -405,6 +406,7 @@ bool MowingBehavior::execute_mowing_plan() {
           // check if we should pause or abort mowing
           if (skip_area) {
             ROS_INFO_STREAM("MowingBehavior: (FIRST POINT) SKIP AREA was requested.");
+            publishMowerEvent("AREA_SKIPPED");
             // remove all paths in current area and return true
             mowerEnabled = false;
             mbfClientExePath->cancelAllGoals();
@@ -521,6 +523,7 @@ bool MowingBehavior::execute_mowing_plan() {
           // check if we should pause or abort mowing
           if (skip_area) {
             ROS_INFO_STREAM("MowingBehavior: (MOW) SKIP AREA was requested.");
+            publishMowerEvent("AREA_SKIPPED");
             // remove all paths in current area and return true
             mowerEnabled = false;
             currentMowingPaths.clear();
@@ -622,6 +625,7 @@ bool MowingBehavior::execute_mowing_plan() {
               }
             }
             ROS_INFO_STREAM("MowingBehavior: (MOW) PAUSED due to MBF Error at " << currentMowingPathIndex);
+            publishMowerEvent("NAVIGATION_ERROR");
             paused = true;
             update_actions();
           }

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
@@ -40,6 +40,8 @@ class MowingBehavior : public Behavior {
   int currentMowingPath;
   int currentMowingArea;
   int currentMowingPathIndex;
+  std::string currentMowingAreaId;
+  std::string currentMowingAreaName;
   std::string currentMowingPlanDigest;
   double currentMowingAngleIncrementSum;
 
@@ -76,7 +78,11 @@ class MowingBehavior : public Behavior {
 
   uint8_t get_state() override;
 
-  int16_t get_current_area();
+  int16_t get_current_area() const;
+
+  std::string get_current_area_id() const;
+
+  std::string get_current_area_name() const;
 
   int16_t get_current_path();
 

--- a/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
@@ -134,6 +134,7 @@ Behavior* UndockingBehavior::execute() {
 
   if (!success) {
     ROS_ERROR_STREAM("Error during undock");
+    publishMowerEvent("UNDOCKING_FAILED", json{{"reason", "path_failed"}});
     return &IdleBehavior::INSTANCE;
   }
 
@@ -146,6 +147,7 @@ Behavior* UndockingBehavior::execute() {
   }
 
   // TODO return mow area
+  publishMowerEvent("UNDOCKED");
   return nextBehavior;
 }
 

--- a/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
@@ -143,6 +143,7 @@ Behavior* UndockingBehavior::execute() {
 
   if (!hasGps) {
     ROS_ERROR_STREAM("Could not get GPS.");
+    publishMowerEvent("UNDOCKING_FAILED", json{{"reason", "no_gps"}});
     return &IdleBehavior::INSTANCE;
   }
 

--- a/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/UndockingBehavior.cpp
@@ -142,8 +142,14 @@ Behavior* UndockingBehavior::execute() {
   bool hasGps = waitForGPS();
 
   if (!hasGps) {
-    ROS_ERROR_STREAM("Could not get GPS.");
-    publishMowerEvent("UNDOCKING_FAILED", json{{"reason", "no_gps"}});
+    if (aborted) {
+      ROS_INFO_STREAM("Undocking aborted while waiting for GPS.");
+    } else if (!ros::ok()) {
+      ROS_INFO_STREAM("ROS shutdown while waiting for GPS.");
+    } else {
+      ROS_ERROR_STREAM("Could not get GPS.");
+      publishMowerEvent("UNDOCKING_FAILED", json{{"reason", "no_gps"}});
+    }
     return &IdleBehavior::INSTANCE;
   }
 

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -61,8 +61,6 @@
 #include "xbot_positioning/GPSControlSrv.h"
 #include "xbot_positioning/SetPoseSrv.h"
 
-using json = nlohmann::ordered_json;
-
 std::string generateNanoId(size_t length = 32) {
   static const char alphabet[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   thread_local std::mt19937 rng{std::random_device{}()};
@@ -242,7 +240,7 @@ bool setGPS(bool enabled) {
 
 // Publishes a mower event. x/y from current pose are always included.
 // "id", "t", and "type" are added by publishEvent().
-void publishMowerEvent(const std::string& type, json details = json::object()) {
+void publishMowerEvent(const std::string& type, json details) {
   const auto& pose = pose_state_subscriber.getMessage();
   details["x"] = pose.pose.pose.position.x;
   details["y"] = pose.pose.pose.position.y;

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -59,7 +59,7 @@
 #include "xbot_positioning/GPSControlSrv.h"
 #include "xbot_positioning/SetPoseSrv.h"
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 ros::ServiceClient pathClient, mapClient, dockingPointClient, gpsClient, mowClient, emergencyClient, pathProgressClient,
     setNavPointClient, clearNavPointClient, clearMapClient, positioningClient, actionRegistrationClient;
@@ -228,11 +228,11 @@ bool setGPS(bool enabled) {
 
 // Publishes a mower event. x/y from current pose are always included.
 // "id", "t", and "type" are added by publishEvent().
-void publishMowerEvent(const std::string& type, json details = nullptr) {
+void publishMowerEvent(const std::string& type, json details = json::object()) {
   const auto& pose = pose_state_subscriber.getMessage();
-  json payload = {{"x", pose.pose.pose.position.x}, {"y", pose.pose.pose.position.y}};
-  if (details.is_object()) payload.update(details);
-  xbot_mqtt::publishEvent(mqtt_publish_pub, type, payload);
+  details["x"] = pose.pose.pose.position.x;
+  details["y"] = pose.pose.pose.position.y;
+  xbot_mqtt::publishEvent(mqtt_publish_pub, type, details);
 }
 
 /// @brief If the BLADE Motor is not in the requested status (enabled),we call the

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -92,6 +92,7 @@ std::recursive_mutex mower_logic_mutex;
 mower_msgs::HighLevelStatus high_level_status;
 
 std::atomic<bool> mowerAllowed;
+std::atomic<bool> shutdown_requested{false};
 
 Behavior* currentBehavior = &IdleBehavior::INSTANCE;
 
@@ -690,8 +691,7 @@ void buildRootActions() {
 }
 
 void shutdownHandler(int) {
-  publishMowerEvent("SHUTDOWN");
-  ros::shutdown();
+  shutdown_requested.store(true, std::memory_order_relaxed);
 }
 
 int main(int argc, char** argv) {
@@ -969,6 +969,11 @@ int main(int argc, char** argv) {
 
   // Behavior execution loop
   while (ros::ok()) {
+    if (shutdown_requested.exchange(false, std::memory_order_relaxed)) {
+      publishMowerEvent("SHUTDOWN");
+      ros::shutdown();
+      break;
+    }
     if (currentBehavior != nullptr) {
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -26,7 +26,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <csignal>
 #include <ios>
 #include <mutex>
 #include <random>
@@ -108,7 +107,6 @@ std::recursive_mutex mower_logic_mutex;
 mower_msgs::HighLevelStatus high_level_status;
 
 std::atomic<bool> mowerAllowed;
-std::atomic<bool> shutdown_requested{false};
 
 Behavior* currentBehavior = &IdleBehavior::INSTANCE;
 
@@ -713,16 +711,10 @@ void buildRootActions() {
   rootActions.push_back(reset_emergency_action);
 }
 
-void shutdownHandler(int) {
-  shutdown_requested.store(true, std::memory_order_relaxed);
-}
-
 int main(int argc, char** argv) {
   buildRootActions();
 
-  ros::init(argc, argv, "mower_logic", ros::init_options::NoSigintHandler);
-  signal(SIGINT, shutdownHandler);
-  signal(SIGTERM, shutdownHandler);
+  ros::init(argc, argv, "mower_logic");
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("~");
@@ -977,7 +969,6 @@ int main(int argc, char** argv) {
   registerActions("mower_logic", rootActions);
 
   ROS_INFO("om_mower_logic: Got all servers, we can mow");
-  publishMowerEvent("BOOTED");
 
   rain_resume = last_rain_check = last_v_battery_check = ros::Time::now();
   ros::Timer safety_timer = n->createTimer(ros::Duration(0.5), checkSafety);
@@ -992,11 +983,6 @@ int main(int argc, char** argv) {
 
   // Behavior execution loop
   while (ros::ok()) {
-    if (shutdown_requested.exchange(false, std::memory_order_relaxed)) {
-      publishMowerEvent("SHUTDOWN");
-      ros::shutdown();
-      break;
-    }
     if (currentBehavior != nullptr) {
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -349,11 +349,16 @@ void stopBlade() {
 /// @brief Stop BLADE motor and any movement
 /// @param emergency
 void setEmergencyMode(bool emergency) {
-  publishMowerEvent("EMERGENCY", json{{"active", emergency}});
   stopBlade();
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
   emergencyStop.request.emergency = emergency;
+
+  static bool last_emergency = false;
+  if (emergency != last_emergency) {
+    publishMowerEvent("EMERGENCY", json{{"emergency", emergency}});
+    last_emergency = emergency;
+  }
 
   ros::Rate retry_delay(1);
   bool success = false;

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -25,6 +25,7 @@
 #include <tf2/LinearMath/Transform.h>
 
 #include <atomic>
+#include <csignal>
 #include <ios>
 #include <mutex>
 #include <sstream>
@@ -52,10 +53,13 @@
 #include "ros/ros.h"
 #include "slic3r_coverage_planner/PlanPath.h"
 #include "std_msgs/String.h"
+#include "xbot_mqtt/publish.h"
 #include "xbot_msgs/AbsolutePose.h"
 #include "xbot_msgs/RegisterActionsSrv.h"
 #include "xbot_positioning/GPSControlSrv.h"
 #include "xbot_positioning/SetPoseSrv.h"
+
+using json = nlohmann::json;
 
 ros::ServiceClient pathClient, mapClient, dockingPointClient, gpsClient, mowClient, emergencyClient, pathProgressClient,
     setNavPointClient, clearNavPointClient, clearMapClient, positioningClient, actionRegistrationClient;
@@ -68,7 +72,7 @@ actionlib::SimpleActionClient<mbf_msgs::MoveBaseAction>* mbfClient;
 actionlib::SimpleActionClient<mbf_msgs::ExePathAction>* mbfClientExePath;
 actionlib::SimpleActionClient<mbf_msgs::RecoveryAction>* mbfClientRecovery;
 
-ros::Publisher cmd_vel_pub, high_level_state_publisher;
+ros::Publisher cmd_vel_pub, high_level_state_publisher, mqtt_publish_pub;
 mower_logic::MowerLogicConfig last_config;
 ll::PowerConfig last_power_config;
 
@@ -221,6 +225,15 @@ bool setGPS(bool enabled) {
   return success;
 }
 
+// Publishes a mower event. x/y from current pose are always included.
+// "id", "t", and "type" are added by publishEvent().
+void publishMowerEvent(const std::string& type, json details = nullptr) {
+  const auto& pose = pose_state_subscriber.getMessage();
+  json payload = {{"x", pose.pose.pose.position.x}, {"y", pose.pose.pose.position.y}};
+  if (details.is_object()) payload.update(details);
+  xbot_mqtt::publishEvent(mqtt_publish_pub, type, payload);
+}
+
 /// @brief If the BLADE Motor is not in the requested status (enabled),we call the
 ///        the mower_service/mow_enabled service to enable/disable. TODO: get feedback about spinup and delay if needed
 /// @param enabled
@@ -237,6 +250,7 @@ bool setMowerEnabled(bool enabled) {
   // status change ?
   const auto last_status = status_state_subscriber.getMessage();
   if (last_status.mow_enabled != enabled) {
+    publishMowerEvent(enabled ? "MOWING_STARTED" : "MOWING_STOPPED");
     ros::Time started = ros::Time::now();
     mower_msgs::MowerControlSrv mow_srv;
     mow_srv.request.mow_enabled = enabled;
@@ -313,6 +327,7 @@ void stopBlade() {
 /// @brief Stop BLADE motor and any movement
 /// @param emergency
 void setEmergencyMode(bool emergency) {
+  publishMowerEvent(emergency ? "EMERGENCY_SET" : "EMERGENCY_CLEARED");
   stopBlade();
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
@@ -338,7 +353,13 @@ void setEmergencyMode(bool emergency) {
 void updateUI(const ros::TimerEvent& timer_event) {
   if (currentBehavior == &MowingBehavior::INSTANCE) {
     try {
-      high_level_status.current_area = MowingBehavior::INSTANCE.get_current_area();
+      const auto& mb = MowingBehavior::INSTANCE;
+      int new_area = mb.get_current_area();
+      if (new_area != high_level_status.current_area && new_area != -1) {
+        publishMowerEvent("AREA_CHANGED",
+                          json{{"area_id", mb.get_current_area_id()}, {"area_name", mb.get_current_area_name()}});
+      }
+      high_level_status.current_area = new_area;
     } catch (const std::runtime_error& re) {
       // specific handling for runtime_error
       ROS_ERROR_STREAM("Error getting current area: " << re.what());
@@ -483,6 +504,16 @@ void checkSafety(const ros::TimerEvent& timer_event) {
     }
   }
 
+  {
+    static bool last_gps_timeout = false;
+    if (gpsTimeout && !last_gps_timeout) {
+      publishMowerEvent("GPS_LOST");
+    } else if (!gpsTimeout && last_gps_timeout) {
+      publishMowerEvent("GPS_RESUMED");
+    }
+    last_gps_timeout = gpsTimeout;
+  }
+
   if (currentBehavior != nullptr && currentBehavior->needs_gps()) {
     currentBehavior->setGoodGPS(!gpsTimeout);
     // Stop the mower
@@ -572,6 +603,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
       currentBehavior != &UndockingBehavior::RETRY_INSTANCE && currentBehavior != &IdleBehavior::INSTANCE &&
       currentBehavior != &IdleBehavior::DOCKED_INSTANCE) {
     ROS_INFO_STREAM(dockingReason.rdbuf());
+    publishMowerEvent("DOCKING", json{{"reason", dockingReason.str()}});
     abortExecution();
   }
 }
@@ -657,10 +689,17 @@ void buildRootActions() {
   rootActions.push_back(reset_emergency_action);
 }
 
+void shutdownHandler(int) {
+  publishMowerEvent("SHUTDOWN");
+  ros::shutdown();
+}
+
 int main(int argc, char** argv) {
   buildRootActions();
 
-  ros::init(argc, argv, "mower_logic");
+  ros::init(argc, argv, "mower_logic", ros::init_options::NoSigintHandler);
+  signal(SIGINT, shutdownHandler);
+  signal(SIGTERM, shutdownHandler);
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("~");
@@ -678,6 +717,7 @@ int main(int argc, char** argv) {
   cmd_vel_pub = n->advertise<geometry_msgs::Twist>("/logic_vel", 1);
 
   high_level_state_publisher = n->advertise<mower_msgs::HighLevelStatus>("mower_logic/current_state", 100, true);
+  mqtt_publish_pub = n->advertise<xbot_mqtt::MqttPublish>("/xbot_monitoring/mqtt_publish", 10);
 
   pathClient = n->serviceClient<slic3r_coverage_planner::PlanPath>("slic3r_coverage_planner/plan_path");
   mapClient = n->serviceClient<mower_map::GetMowingAreaSrv>("mower_map_service/get_mowing_area");
@@ -914,6 +954,7 @@ int main(int argc, char** argv) {
   registerActions("mower_logic", rootActions);
 
   ROS_INFO("om_mower_logic: Got all servers, we can mow");
+  publishMowerEvent("BOOTED");
 
   rain_resume = last_rain_check = last_v_battery_check = ros::Time::now();
   ros::Timer safety_timer = n->createTimer(ros::Duration(0.5), checkSafety);
@@ -932,6 +973,11 @@ int main(int argc, char** argv) {
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();
       currentBehavior->exit();
+
+      if (newBehavior != currentBehavior && newBehavior != nullptr) {
+        publishMowerEvent("STATE_CHANGED", json{{"state", newBehavior->state_name()}});
+      }
+
       currentBehavior = newBehavior;
     } else {
       high_level_status.state_name = "NULL";

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -24,16 +24,19 @@
 #include <mower_msgs/Power.h>
 #include <tf2/LinearMath/Transform.h>
 
+#include <algorithm>
 #include <atomic>
 #include <csignal>
 #include <ios>
 #include <mutex>
+#include <random>
 #include <sstream>
 
 #include "StateSubscriber.h"
 #include "behaviors/AreaRecordingBehavior.h"
 #include "behaviors/Behavior.h"
 #include "behaviors/IdleBehavior.h"
+#include "behaviors/PerimeterDocking.h"
 #include "ftc_local_planner/PlannerGetProgress.h"
 #include "mbf_msgs/ExePathAction.h"
 #include "mbf_msgs/MoveBaseAction.h"
@@ -60,6 +63,19 @@
 #include "xbot_positioning/SetPoseSrv.h"
 
 using json = nlohmann::ordered_json;
+
+std::string generateNanoId(size_t length = 32) {
+  static const char alphabet[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  thread_local std::mt19937 rng{std::random_device{}()};
+  thread_local std::uniform_int_distribution<> dist(0, sizeof(alphabet) - 2);
+  std::string id(length, '\0');
+  std::generate_n(id.begin(), length, [&]() { return alphabet[dist(rng)]; });
+  return id;
+}
+
+std::string current_job_id;
+std::string current_session_id;
+bool current_job_finished = false;
 
 ros::ServiceClient pathClient, mapClient, dockingPointClient, gpsClient, mowClient, emergencyClient, pathProgressClient,
     setNavPointClient, clearNavPointClient, clearMapClient, positioningClient, actionRegistrationClient;
@@ -232,6 +248,8 @@ void publishMowerEvent(const std::string& type, json details = json::object()) {
   const auto& pose = pose_state_subscriber.getMessage();
   details["x"] = pose.pose.pose.position.x;
   details["y"] = pose.pose.pose.position.y;
+  if (!current_job_id.empty()) details["job_id"] = current_job_id;
+  if (!current_session_id.empty()) details["session_id"] = current_session_id;
   xbot_mqtt::publishEvent(mqtt_publish_pub, type, details);
 }
 
@@ -396,6 +414,8 @@ void updateUI(const ros::TimerEvent& timer_event) {
     high_level_status.sub_state_name = "";
     high_level_status.state = mower_msgs::HighLevelStatus::HIGH_LEVEL_STATE_NULL;
   }
+  high_level_status.job_id = current_job_id;
+  high_level_status.session_id = current_session_id;
   high_level_state_publisher.publish(high_level_status);
 }
 
@@ -981,6 +1001,24 @@ int main(int argc, char** argv) {
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();
       currentBehavior->exit();
+
+      if (newBehavior != nullptr) {
+        // Session START: undocking begins a new session; mowing is the fallback for idle-start (not on charger)
+        if (newBehavior == &UndockingBehavior::INSTANCE || newBehavior == &PerimeterUndockingBehavior::INSTANCE ||
+            (newBehavior == &MowingBehavior::INSTANCE && current_session_id.empty())) {
+          if (current_job_id.empty()) current_job_id = generateNanoId();
+          current_session_id = generateNanoId();
+        }
+
+        // Session END: entering either idle variant (docked or not)
+        if (newBehavior == &IdleBehavior::INSTANCE || newBehavior == &IdleBehavior::DOCKED_INSTANCE) {
+          current_session_id = "";
+          if (current_job_finished) {
+            current_job_id = "";
+            current_job_finished = false;
+          }
+        }
+      }
 
       if (newBehavior != currentBehavior && newBehavior != nullptr) {
         publishMowerEvent("STATE", json{{"state", newBehavior->state_name()}});

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -240,6 +240,13 @@ void publishMowerEvent(const std::string& type, json details = json::object()) {
 /// @param enabled
 /// @return
 bool setMowerEnabled(bool enabled) {
+  const auto last_status = status_state_subscriber.getMessage();
+
+  // For events, publish the intended state, ignoring the config.
+  if (last_status.mow_enabled != enabled) {
+    publishMowerEvent("BLADES", json{{"enabled", enabled}});
+  }
+
   const auto last_config = getConfig();
 
   if (!last_config.enable_mower && enabled) {
@@ -249,9 +256,7 @@ bool setMowerEnabled(bool enabled) {
   }
 
   // status change ?
-  const auto last_status = status_state_subscriber.getMessage();
   if (last_status.mow_enabled != enabled) {
-    publishMowerEvent(enabled ? "MOWING_STARTED" : "MOWING_STOPPED");
     ros::Time started = ros::Time::now();
     mower_msgs::MowerControlSrv mow_srv;
     mow_srv.request.mow_enabled = enabled;
@@ -328,7 +333,7 @@ void stopBlade() {
 /// @brief Stop BLADE motor and any movement
 /// @param emergency
 void setEmergencyMode(bool emergency) {
-  publishMowerEvent(emergency ? "EMERGENCY_SET" : "EMERGENCY_CLEARED");
+  publishMowerEvent("EMERGENCY", json{{"active", emergency}});
   stopBlade();
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
@@ -357,7 +362,7 @@ void updateUI(const ros::TimerEvent& timer_event) {
       const auto& mb = MowingBehavior::INSTANCE;
       int new_area = mb.get_current_area();
       if (new_area != high_level_status.current_area && new_area != -1) {
-        publishMowerEvent("AREA_CHANGED",
+        publishMowerEvent("AREA",
                           json{{"area_id", mb.get_current_area_id()}, {"area_name", mb.get_current_area_name()}});
       }
       high_level_status.current_area = new_area;
@@ -506,13 +511,11 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   }
 
   {
-    static bool last_gps_timeout = false;
-    if (gpsTimeout && !last_gps_timeout) {
-      publishMowerEvent("GPS_LOST");
-    } else if (!gpsTimeout && last_gps_timeout) {
-      publishMowerEvent("GPS_RESUMED");
+    static bool last_gps_timeout = true;
+    if (gpsTimeout != last_gps_timeout) {
+      publishMowerEvent("GPS", json{{"available", !gpsTimeout}});
+      last_gps_timeout = gpsTimeout;
     }
-    last_gps_timeout = gpsTimeout;
   }
 
   if (currentBehavior != nullptr && currentBehavior->needs_gps()) {
@@ -980,7 +983,7 @@ int main(int argc, char** argv) {
       currentBehavior->exit();
 
       if (newBehavior != currentBehavior && newBehavior != nullptr) {
-        publishMowerEvent("STATE_CHANGED", json{{"state", newBehavior->state_name()}});
+        publishMowerEvent("STATE", json{{"state", newBehavior->state_name()}});
       }
 
       currentBehavior = newBehavior;

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -571,7 +571,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   // we are in non emergency, check if we should pause. This could be empty battery, rain or hot mower motor etc.
   bool dockingNeeded = false;
 
-  std::stringstream dockingReason("Docking: ", std::ios_base::ate | std::ios_base::in | std::ios_base::out);
+  std::stringstream dockingReason(std::ios_base::ate | std::ios_base::in | std::ios_base::out);
 
   if (last_config.manual_pause_mowing) {
     dockingReason << "Manual pause";
@@ -580,7 +580,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
 
   // Dock if below critical voltage to avoid BMS undervoltage protection
   if (!dockingNeeded && (last_battery_v < last_power_config.battery_critical_voltage)) {
-    dockingReason << "Battery voltage min critical: " << last_battery_v;
+    dockingReason << "Battery voltage critical: " << last_battery_v << " V";
     dockingNeeded = true;
   }
 
@@ -588,7 +588,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   max_v_battery_seen = std::max<double>(max_v_battery_seen, last_battery_v);
   if (ros::Time::now() - last_v_battery_check > ros::Duration(20.0)) {
     if (!dockingNeeded && (max_v_battery_seen < last_power_config.battery_empty_voltage)) {
-      dockingReason << "Battery average voltage low: " << max_v_battery_seen;
+      dockingReason << "Battery average voltage low: " << max_v_battery_seen << " V";
       dockingNeeded = true;
     }
     max_v_battery_seen = 0.0;
@@ -596,7 +596,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   }
 
   if (!dockingNeeded && last_status.mower_motor_temperature >= last_config.motor_hot_temperature) {
-    dockingReason << "Mow motor over temp: " << last_status.mower_motor_temperature;
+    dockingReason << "Mow motor over temp: " << last_status.mower_motor_temperature << " °C";
     dockingNeeded = true;
   }
 
@@ -626,7 +626,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   if (dockingNeeded && currentBehavior != &DockingBehavior::INSTANCE &&
       currentBehavior != &UndockingBehavior::RETRY_INSTANCE && currentBehavior != &IdleBehavior::INSTANCE &&
       currentBehavior != &IdleBehavior::DOCKED_INSTANCE) {
-    ROS_INFO_STREAM(dockingReason.rdbuf());
+    ROS_INFO_STREAM("Docking: " << dockingReason.rdbuf());
     publishMowerEvent("DOCKING", json{{"reason", dockingReason.str()}});
     abortExecution();
   }

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -1,3 +1,4 @@
+string id
 string name
 bool active
 geometry_msgs/Polygon area

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -260,7 +260,7 @@ MapArea obstacleToInternal(const geometry_msgs::Polygon& obstacle, bool active) 
  */
 MapArea mowerMapAreaToInternal(const mower_map::MapArea& area, const std::string& type) {
   MapArea result;
-  result.id = generateNanoId();
+  result.id = area.id.empty() ? generateNanoId() : area.id;
   result.type = type;
   result.name = area.name;
   result.active = area.active;
@@ -277,6 +277,7 @@ MapArea mowerMapAreaToInternal(const mower_map::MapArea& area, const std::string
  */
 mower_map::MapArea internalMapAreaToMower(const MapArea& area) {
   mower_map::MapArea result;
+  result.id = area.id;
   result.name = area.name;
   result.active = area.active;
   result.angle = area.angle;

--- a/src/mower_msgs/msg/HighLevelStatus.msg
+++ b/src/mower_msgs/msg/HighLevelStatus.msg
@@ -12,6 +12,8 @@ uint8 SUBSTATE_SHIFT=6
 uint8 state
 string state_name
 string sub_state_name
+string job_id
+string session_id
 int16 current_area
 int16 current_path
 int16 current_path_index


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent event and position histories with JSON-RPC endpoints to list and delete entries (filterable by date/job).
  * Extended monitoring capabilities for events and position.
  * Enhanced MQTT mower lifecycle notifications with job/session IDs plus new docking/charging/GPS-related event types.
* **Bug Fixes**
  * Preserve `MapArea` IDs when converting between map messages and internal representations.
* **Refactor**
  * Improved pose sampling and monitoring initialization/timer shutdown handling for safer runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->