### PR TITLE
Added user to input group

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,9 +80,11 @@ RUN chmod +x /openmower_entrypoint.sh
 ARG USERNAME=openmower
 ARG USER_UID=1000
 ARG USER_GID=1000
-RUN groupadd --gid ${USER_GID} ${USERNAME} \
+RUN groupadd --gid ${USER_GID} ${USERNAME} && \
+    groupadd -g 996 input \
     && useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --shell /bin/bash ${USERNAME} \
     && adduser ${USERNAME} dialout \
+    && adduser ${USERNAME} input \
     && chown -R ${USER_UID}:${USER_GID} /config /home/${USERNAME}
 
 # Append our bashrc extension to user's .bashrc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Create an "input" group (GID 996) in the runtime image and add the runtime user to it, in addition to the existing dialout membership, to grant the container process extra device/access permissions.
  * Preserve existing ownership and permissions of /config and the runtime user's home directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->