### PR TITLE
Fix charge and battery voltages on fontend

### DIFF
--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -150,7 +150,7 @@ void power_received(const mower_msgs::Power::ConstPtr& msg) {
   {
     xbot_msgs::SensorDataDouble sensor_data;
     sensor_data.stamp = msg->stamp;
-    sensor_data.data = msg->charge_voltage_chg;
+    sensor_data.data = msg->charge_voltage_chg > 0.0 ? msg->charge_voltage_chg : msg->charge_voltage_adc;
 
     auto sc_it = sensor_configs.find("om_v_charge");
     if (sc_it != std::end(sensor_configs)) {
@@ -160,7 +160,7 @@ void power_received(const mower_msgs::Power::ConstPtr& msg) {
   {
     xbot_msgs::SensorDataDouble sensor_data;
     sensor_data.stamp = msg->stamp;
-    sensor_data.data = msg->battery_voltage_chg;
+    sensor_data.data = msg->battery_voltage_chg > 0.0 ? msg->battery_voltage_chg : msg->battery_voltage_adc;
 
     auto sc_it = sensor_configs.find("om_v_battery");
     if (sc_it != std::end(sensor_configs)) {


### PR DESCRIPTION
Use ADC voltages for frontend, if the charger provided ones are not available (e.g. V1 hardware)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced voltage monitoring reliability by implementing fallback sensor values when primary readings return invalid data, ensuring more consistent voltage measurements under edge case conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->