### PR TITLE
Protect xbot_monitoring against deadlocks

### DIFF
--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -40,15 +40,14 @@ void rpc_request_callback(const std::string &payload);
 
 // Stores registered actions (prefix to vector<action>)
 std::map<std::string, std::vector<xbot_msgs::ActionInfo>> registered_actions;
+std::mutex registered_actions_mutex;
 
 // Stores registered RPC methods
 std::map<std::string, std::vector<std::string>> registered_methods;
 std::mutex registered_methods_mutex;
 
-// Maps a topic to a subscriber.
-std::map<std::string, ros::Subscriber> active_subscribers;
 std::map<std::string, xbot_msgs::SensorInfo> found_sensors;
-std::vector<ros::Subscriber> sensor_data_subscribers;
+std::mutex found_sensors_mutex;
 
 ros::NodeHandle *n;
 
@@ -56,7 +55,6 @@ ros::NodeHandle *n;
 std::shared_ptr<mqtt::async_client> client_;
 std::shared_ptr<mqtt::async_client> client_external_;
 
-std::mutex mqtt_callback_mutex;
 
 // Publisher for cmd_vel and commands
 ros::Publisher cmd_vel_pub;
@@ -139,7 +137,9 @@ MqttCallback mqtt_callback;
 MqttCallback mqtt_callback_external;
 
 json map;
+std::mutex map_mutex;
 json map_overlay;
+std::mutex map_overlay_mutex;
 bool has_map = false;
 bool has_map_overlay = false;
 
@@ -349,78 +349,80 @@ void publish_params() {
 }
 
 void publish_sensor_metadata() {
-    std::unique_lock<std::mutex> lk(mqtt_callback_mutex);
-
-    if(found_sensors.empty())
-        return;
-
     json sensor_info;
-    for (const auto &kv: found_sensors) {
-        json info;
-        info["sensor_id"] = kv.second.sensor_id;
-        info["sensor_name"] = kv.second.sensor_name;
+    {
+        std::unique_lock<std::mutex> lk(found_sensors_mutex);
 
-        switch (kv.second.value_type) {
-            case xbot_msgs::SensorInfo::TYPE_STRING: {
-                info["value_type"] = "STRING";
-                break;
-            }
-            case xbot_msgs::SensorInfo::TYPE_DOUBLE: {
-                info["value_type"] = "DOUBLE";
-                break;
-            }
-            default: {
-                info["value_type"] = "UNKNOWN";
-                break;
-            }
+        if(found_sensors.empty())
+            return;
+
+        for (const auto &kv: found_sensors) {
+            json info;
+            info["sensor_id"] = kv.second.sensor_id;
+            info["sensor_name"] = kv.second.sensor_name;
+
+            switch (kv.second.value_type) {
+                case xbot_msgs::SensorInfo::TYPE_STRING: {
+                    info["value_type"] = "STRING";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::TYPE_DOUBLE: {
+                    info["value_type"] = "DOUBLE";
+                    break;
+                }
+                default: {
+                    info["value_type"] = "UNKNOWN";
+                    break;
+                }
 
 
+            }
+
+            switch (kv.second.value_description) {
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE: {
+                    info["value_description"] = "TEMPERATURE";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_VELOCITY: {
+                    info["value_description"] = "VELOCITY";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_ACCELERATION: {
+                    info["value_description"] = "ACCELERATION";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_VOLTAGE: {
+                    info["value_description"] = "VOLTAGE";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_CURRENT: {
+                    info["value_description"] = "CURRENT";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_PERCENT: {
+                    info["value_description"] = "PERCENT";
+                    break;
+                }
+                case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM: {
+                    info["value_description"] = "REVOLUTIONS";
+                    break;
+                }
+                default: {
+                    info["value_description"] = "UNKNOWN";
+                    break;
+                }
+            }
+
+            info["unit"] = kv.second.unit;
+            info["has_min_max"] = kv.second.has_min_max;
+            info["min_value"] = kv.second.min_value;
+            info["max_value"] = kv.second.max_value;
+            info["has_critical_low"] = kv.second.has_critical_low;
+            info["lower_critical_value"] = kv.second.lower_critical_value;
+            info["has_critical_high"] = kv.second.has_critical_high;
+            info["upper_critical_value"] = kv.second.upper_critical_value;
+            sensor_info.push_back(info);
         }
-
-        switch (kv.second.value_description) {
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE: {
-                info["value_description"] = "TEMPERATURE";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_VELOCITY: {
-                info["value_description"] = "VELOCITY";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_ACCELERATION: {
-                info["value_description"] = "ACCELERATION";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_VOLTAGE: {
-                info["value_description"] = "VOLTAGE";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_CURRENT: {
-                info["value_description"] = "CURRENT";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_PERCENT: {
-                info["value_description"] = "PERCENT";
-                break;
-            }
-            case xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM: {
-                info["value_description"] = "REVOLUTIONS";
-                break;
-            }
-            default: {
-                info["value_description"] = "UNKNOWN";
-                break;
-            }
-        }
-
-        info["unit"] = kv.second.unit;
-        info["has_min_max"] = kv.second.has_min_max;
-        info["min_value"] = kv.second.min_value;
-        info["max_value"] = kv.second.max_value;
-        info["has_critical_low"] = kv.second.has_critical_low;
-        info["lower_critical_value"] = kv.second.lower_critical_value;
-        info["has_critical_high"] = kv.second.has_critical_high;
-        info["upper_critical_value"] = kv.second.upper_critical_value;
-        sensor_info.push_back(info);
     }
     try_publish("sensor_infos/json", sensor_info.dump(), true);
     json data;
@@ -429,8 +431,12 @@ void publish_sensor_metadata() {
     try_publish_binary("sensor_infos/bson", bson.data(), bson.size(), true);
 }
 
-void subscribe_to_sensor(std::string topic) {
-    auto &sensor = found_sensors[topic];
+void subscribe_to_sensor(std::string topic, std::vector<ros::Subscriber> &sensor_data_subscribers) {
+    xbot_msgs::SensorInfo sensor;
+    {
+        std::unique_lock<std::mutex> lk(found_sensors_mutex);
+        sensor = found_sensors[topic];
+    }
 
     ROS_INFO_STREAM("Subscribing to sensor data for sensor with name: " << sensor.sensor_name);
 
@@ -438,7 +444,7 @@ void subscribe_to_sensor(std::string topic) {
 
     switch (sensor.value_type) {
         case xbot_msgs::SensorInfo::TYPE_DOUBLE: {
-            ros::Subscriber s = n->subscribe<xbot_msgs::SensorDataDouble>(data_topic, 10, [&info = sensor](
+            ros::Subscriber s = n->subscribe<xbot_msgs::SensorDataDouble>(data_topic, 10, [info = sensor](
                     const xbot_msgs::SensorDataDouble::ConstPtr &msg) {
                 try_publish("sensors/" + info.sensor_id + "/data", std::to_string(msg->data));
 
@@ -451,7 +457,7 @@ void subscribe_to_sensor(std::string topic) {
             break;
         }
         case xbot_msgs::SensorInfo::TYPE_STRING: {
-            ros::Subscriber s = n->subscribe<xbot_msgs::SensorDataString>(data_topic, 10, [&info = sensor](
+            ros::Subscriber s = n->subscribe<xbot_msgs::SensorDataString>(data_topic, 10, [info = sensor](
                     const xbot_msgs::SensorDataString::ConstPtr &msg) {
                 try_publish("sensors/" + info.sensor_id + "/data", msg->data);
 
@@ -500,13 +506,16 @@ void robot_state_callback(const xbot_msgs::RobotState::ConstPtr &msg) {
 
 void publish_actions() {
     json actions = json::array();
-    for(const auto &kv : registered_actions) {
-        for(const auto &action : kv.second) {
-            json action_info;
-            action_info["action_id"] = kv.first + "/" + action.action_id;
-            action_info["action_name"] = action.action_name;
-            action_info["enabled"] = action.enabled;
-            actions.push_back(action_info);
+    {
+        std::lock_guard<std::mutex> lk(registered_actions_mutex);
+        for(const auto &kv : registered_actions) {
+            for(const auto &action : kv.second) {
+                json action_info;
+                action_info["action_id"] = kv.first + "/" + action.action_id;
+                action_info["action_name"] = action.action_name;
+                action_info["enabled"] = action.enabled;
+                actions.push_back(action_info);
+            }
         }
     }
 
@@ -519,29 +528,43 @@ void publish_actions() {
 }
 
 void publish_map() {
-    if(!has_map)
-        return;
-    try_publish("map/json", map.dump(2), true);
+    json m;
+    {
+        std::lock_guard<std::mutex> lk(map_mutex);
+        if(!has_map)
+            return;
+        m = map;
+    }
+    try_publish("map/json", m.dump(2), true);
     json data;
-    data["d"] = map;
+    data["d"] = m;
     auto bson = json::to_bson(data);
     try_publish_binary("map/bson", bson.data(), bson.size(), true);
 }
 
 void publish_map_overlay() {
-    if(!has_map_overlay)
-        return;
-    try_publish("map_overlay/json", map_overlay.dump(), true);
+    json m;
+    {
+        std::lock_guard<std::mutex> lk(map_overlay_mutex);
+        if(!has_map_overlay)
+            return;
+        m = map_overlay;
+    }
+    try_publish("map_overlay/json", m.dump(), true);
     json data;
-    data["d"] = map_overlay;
+    data["d"] = m;
     auto bson = json::to_bson(data);
     try_publish_binary("map_overlay/bson", bson.data(), bson.size(), true);
 }
 
 void map_callback(const std_msgs::String::ConstPtr &msg) {
     try {
-        map = json::parse(msg->data);
-        has_map = true;
+        json m = json::parse(msg->data);
+        {
+            std::lock_guard<std::mutex> lk(map_mutex);
+            map = m;
+            has_map = true;
+        }
         publish_map();
     } catch (const json::exception &e) {
         ROS_ERROR_STREAM("Error processing map JSON: " << e.what());
@@ -575,8 +598,11 @@ void map_overlay_callback(const xbot_msgs::MapOverlay::ConstPtr &msg) {
 
     json j;
     j["polygons"] = polys;
-    map_overlay = j;
-    has_map_overlay = true;
+    {
+        std::lock_guard<std::mutex> lk(map_overlay_mutex);
+        map_overlay = j;
+        has_map_overlay = true;
+    }
 
     publish_map_overlay();
 }
@@ -586,7 +612,10 @@ bool registerActions(xbot_msgs::RegisterActionsSrvRequest &req, xbot_msgs::Regis
 
     ROS_INFO_STREAM("new actions registered: " << req.node_prefix << " registered " << req.actions.size() << " actions.");
 
-    registered_actions[req.node_prefix] = req.actions;
+    {
+        std::lock_guard<std::mutex> lk(registered_actions_mutex);
+        registered_actions[req.node_prefix] = req.actions;
+    }
 
     publish_actions();
     return true;
@@ -714,11 +743,6 @@ int main(int argc, char **argv) {
     cmd_vel_pub = n->advertise<geometry_msgs::Twist>("xbot_monitoring/remote_cmd_vel", 1);
     action_pub = n->advertise<std_msgs::String>("xbot/action", 1);
 
-    rpc_request_pub = n->advertise<xbot_rpc::RpcRequest>(xbot_rpc::TOPIC_REQUEST, 100);
-    ros::Subscriber rpc_response_sub = n->subscribe(xbot_rpc::TOPIC_RESPONSE, 100, rpc_response_callback);
-    ros::Subscriber rpc_error_sub = n->subscribe(xbot_rpc::TOPIC_ERROR, 100, rpc_error_callback);
-    ros::ServiceServer register_methods_service = n->advertiseService(xbot_rpc::SERVICE_REGISTER_METHODS, register_methods);
-
     ros::AsyncSpinner spinner(1);
     spinner.start();
 
@@ -727,6 +751,10 @@ int main(int argc, char **argv) {
     ros::Rate sensor_check_rate(10.0);
 
     boost::regex topic_regex("/xbot_monitoring/sensors/.*/info");
+
+    // Maps a sensor info topic to its subscriber. Only touched by this thread.
+    std::map<std::string, ros::Subscriber> active_subscribers;
+    std::vector<ros::Subscriber> sensor_data_subscribers;
 
     while (ros::ok()) {
         // Read the topics in /xbot_monitoring/sensors/.*/info and subscribe to them.
@@ -739,25 +767,25 @@ int main(int argc, char **argv) {
 
             ROS_INFO_STREAM("Found new sensor topic " << item.name);
             active_subscribers[item.name] = n->subscribe<xbot_msgs::SensorInfo>(
-                item.name, 1, [topic = item.name](const xbot_msgs::SensorInfo::ConstPtr &msg) {
+                item.name, 1, [topic = item.name, &sensor_data_subscribers](const xbot_msgs::SensorInfo::ConstPtr &msg) {
                     ROS_INFO_STREAM("Got sensor info for sensor on topic " << msg->sensor_name << " on topic " << topic);
-                    auto exist = found_sensors.count(topic);
 
-                    // Sensor already known and sensor-info equals?
-                    if(exist != 0 && found_sensors[topic] == *msg)
-                        return;
-
+                    bool is_new = false;
                     {
-                        // Sensor is new or sensor-info differ from the buffered one
-                        std::unique_lock<std::mutex> lk(mqtt_callback_mutex);
+                        std::unique_lock<std::mutex> lk(found_sensors_mutex);
+                        is_new = found_sensors.count(topic) == 0;
+
+                        // Sensor already known and sensor-info equals?
+                        if (!is_new && found_sensors[topic] == *msg) return;
+
                         found_sensors[topic] = *msg;  // Save the (new|changed) sensor info
                     }
 
                     // Let the info subscription alive for dynamic threshold changes
                     //active_subscribers.erase(topic);  // Stop subscribing to infos
 
-                    if (exist == 0) {
-                        subscribe_to_sensor(topic);  // Subscribe for data
+                    if (is_new) {
+                        subscribe_to_sensor(topic, sensor_data_subscribers);  // Subscribe for data
                     }
 
                     // Republish (new|changed) sensor info


### PR DESCRIPTION
This seems to have fixed ROS not properly starting after a reboot. Gemini did most of this after seeing the thread backtraces of that deadlock. I did some follow-ups and then tested it on the mower. 3-4 restarts in a row worked fine, while previously it hung in pretty much every reboot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to state management and synchronization for enhanced system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->