### PR TITLE
Fix map obstacle processing order

### DIFF
--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -411,19 +411,24 @@ void buildMap() {
   for (const auto& area : map_data.areas) {
     if (!area.active) continue;
 
-    double value;
     if (area.type == "mow" || area.type == "nav") {
-      value = 0.0;
-    } else if (area.type == "obstacle") {
-      value = 1.0;
-    } else {
-      continue;
+      grid_map::Polygon poly = internalPolygonToGridMap(area.outline);
+      for (grid_map::PolygonIterator iterator(map, poly); !iterator.isPastEnd(); ++iterator) {
+        const grid_map::Index index(*iterator);
+        data(index[0], index[1]) = 0.0;
+      }
     }
+  }
 
-    grid_map::Polygon poly = internalPolygonToGridMap(area.outline);
-    for (grid_map::PolygonIterator iterator(map, poly); !iterator.isPastEnd(); ++iterator) {
-      const grid_map::Index index(*iterator);
-      data(index[0], index[1]) = value;
+  for (const auto& area : map_data.areas) {
+    if (!area.active) continue;
+
+    if (area.type == "obstacle") {
+      grid_map::Polygon poly = internalPolygonToGridMap(area.outline);
+      for (grid_map::PolygonIterator iterator(map, poly); !iterator.isPastEnd(); ++iterator) {
+        const grid_map::Index index(*iterator);
+        data(index[0], index[1]) = 1.0;
+      }
     }
   }
 


### PR DESCRIPTION
Set obstacle costs only after all map/nav areas have been cleared. Otherwise a map/nav area can clear an existing obstacle cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized map building process with improved grid initialization logic for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->