### PR TITLE
external_mqtt_topic_prefix 

### DIFF
--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -211,7 +211,7 @@ void setupMqttClient() {
 
         try {
             client_external_ = std::make_shared<mqtt::async_client>(
-                    uri, "ext_xbot_monitoring");
+                    uri, "ext_xbot_monitoring_" + external_mqtt_topic_prefix);
             mqtt_callback_external.setMqttClient(client_external_, external_mqtt_topic_prefix);
             client_external_->set_callback(mqtt_callback_external);
 

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -178,8 +178,15 @@ void setupMqttClient() {
                           std::string(":") + std::to_string(1883);
 
         try {
-            client_ = std::make_shared<mqtt::async_client>(
-                    uri, "xbot_monitoring");
+            std::string external_client_id =
+                    "ext_xm_" + std::to_string(std::hash<std::string>{}(external_mqtt_topic_prefix));
+            
+            if (external_client_id.length() > 23) {
+                external_client_id = external_client_id.substr(0, 23);
+            }
+            
+            client_external_ = std::make_shared<mqtt::async_client>(
+                    uri, external_client_id);
             mqtt_callback.setMqttClient(client_, "");
             client_->set_callback(mqtt_callback);
 

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -178,15 +178,8 @@ void setupMqttClient() {
                           std::string(":") + std::to_string(1883);
 
         try {
-            std::string external_client_id =
-                    "ext_xm_" + std::to_string(std::hash<std::string>{}(external_mqtt_topic_prefix));
-            
-            if (external_client_id.length() > 23) {
-                external_client_id = external_client_id.substr(0, 23);
-            }
-            
-            client_external_ = std::make_shared<mqtt::async_client>(
-                    uri, external_client_id);
+            client_ = std::make_shared<mqtt::async_client>(
+                    uri, "xbot_monitoring");
             mqtt_callback.setMqttClient(client_, "");
             client_->set_callback(mqtt_callback);
 
@@ -214,8 +207,16 @@ void setupMqttClient() {
         }
 
         // create MQTT client
-        std::string uri = "tcp" + std::string("://") + external_mqtt_hostname +
-                          std::string(":") + external_mqtt_port;
+        
+        std::string external_client_id =
+                "ext_xm_" + std::to_string(std::hash<std::string>{}(external_mqtt_topic_prefix));
+        
+        if (external_client_id.length() > 23) {
+            external_client_id = external_client_id.substr(0, 23);
+        }
+        
+        client_external_ = std::make_shared<mqtt::async_client>(
+                uri, external_client_id);
 
         try {
             std::string external_client_id =

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -26,6 +26,7 @@
 #include "xbot_rpc/provider.h"
 #include "xbot_rpc/RegisterMethodsSrv.h"
 #include "capabilities.h"
+#include <functional>
 
 using json = nlohmann::ordered_json;
 
@@ -210,8 +211,15 @@ void setupMqttClient() {
                           std::string(":") + external_mqtt_port;
 
         try {
+            std::string external_client_id =
+                    "ext_xm_" + std::to_string(std::hash<std::string>{}(external_mqtt_topic_prefix));
+            
+            if (external_client_id.length() > 23) {
+                external_client_id = external_client_id.substr(0, 23);
+            }
+            
             client_external_ = std::make_shared<mqtt::async_client>(
-                    uri, "ext_xbot_monitoring_" + external_mqtt_topic_prefix);
+                    uri, external_client_id);
             mqtt_callback_external.setMqttClient(client_external_, external_mqtt_topic_prefix);
             client_external_->set_callback(mqtt_callback_external);
 


### PR DESCRIPTION
Problem

Running multiple OpenMower instances with MQTT enabled causes client ID collisions because all instances use the same hardcoded client ID:

ext_xbot_monitoring

This results in:

MQTT disconnect/reconnect loops
delayed or missing updates in Home Assistant

Solution

Use external_mqtt_topic_prefix to generate a unique client ID:

"ext_xbot_monitoring_" + external_mqtt_topic_prefix

Result

Multiple mowers can run simultaneously
Stable MQTT updates (~5s)
No broker conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * External MQTT client identifier is now derived from the topic prefix and constrained to the platform's client-ID length limits to reduce collision risk. Client initialization, callbacks, connection URI and credentials remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->