### PR TITLE
Allow area recording after manual home

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
@@ -21,6 +21,8 @@ extern actionlib::SimpleActionClient<mbf_msgs::ExePathAction>* mbfClientExePath;
 extern ros::NodeHandle* n;
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
 
+extern mower_logic::MowerLogicConfig getConfig();
+extern void setConfig(mower_logic::MowerLogicConfig);
 extern void stop();
 
 extern bool setGPS(bool enabled);
@@ -169,6 +171,13 @@ void AreaRecordingBehavior::enter() {
   marker_array_pub = n->advertise<visualization_msgs::MarkerArray>("area_recorder/progress_visualization_array", 10);
 
   ROS_INFO_STREAM("Starting recording area");
+
+  auto last_config = getConfig();
+  if (last_config.manual_pause_mowing) {
+    ROS_INFO_STREAM("There was a manual pause, but we don't care");
+    last_config.manual_pause_mowing = false;
+    setConfig(last_config);
+  }
 
   ROS_INFO_STREAM("Subscribing to /joy for user input");
 


### PR DESCRIPTION
If you have pressed home and the mower is docked. After that you cannot run area recording as it is aborting on manual_pause_mowing. This change will detect that manual_pause_mowing is set and clear it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manual pause flags during area recording initialization. The mower now properly clears pause states when entering area recording mode to ensure correct operation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->