### PR TITLE
Add optional outline_count in map.json for areas

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -193,7 +193,8 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
   // calculate coverage
   slic3r_coverage_planner::PlanPath pathSrv;
   pathSrv.request.angle = angle;
-  pathSrv.request.outline_count = config.outline_count;
+  pathSrv.request.outline_count =
+      (mapSrv.response.area.outline_count >= 0) ? mapSrv.response.area.outline_count : config.outline_count;
   pathSrv.request.outline_overlap_count = config.outline_overlap_count;
   pathSrv.request.outline = mapSrv.response.area.area;
   pathSrv.request.holes = mapSrv.response.area.obstacles;

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -1,3 +1,4 @@
 string name
 geometry_msgs/Polygon area
 geometry_msgs/Polygon[] obstacles
+int32 outline_count  # per-area override; -1 means use the global config value

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -75,6 +75,7 @@ struct MapArea {
   std::string type;
   bool active;
   Polygon outline;
+  int outline_count = -1;
 };
 
 struct DockingStation {
@@ -114,6 +115,7 @@ void to_json(json& j, const MapArea& data) {
   if (!data.name.empty()) properties["name"] = data.name;
   properties["type"] = data.type;
   if (!data.active) properties["active"] = data.active;
+  if (data.outline_count >= 0) properties["outline_count"] = data.outline_count;
   j["properties"] = properties;
   j["outline"] = data.outline;
 }
@@ -124,6 +126,7 @@ void from_json(const json& j, MapArea& data) {
   data.name = properties.value("name", "");
   data.type = properties.value("type", "draft");
   data.active = properties.value("active", true);
+  data.outline_count = properties.value("outline_count", -1);
   j.at("outline").get_to(data.outline);
 }
 
@@ -246,6 +249,7 @@ MapArea mowerMapAreaToInternal(const geometry_msgs::Polygon& area, const std::st
 mower_map::MapArea internalMapAreaToMower(const MapArea& area) {
   mower_map::MapArea result;
   result.name = area.name;
+  result.outline_count = area.outline_count;
   // Leave area empty if it is not active
   if (area.active) {
     result.area = internalPolygonToGeometry(area.outline);


### PR DESCRIPTION
This PR adds the option to have outline_count defined in map.json on a per-area basis. It allows the user to set the number of outlines per area.

My specific use case is one area which exists only of narrow paths. Mowing this with infill is very slow, but mowing it as 100% outline works fine. If outline is set to max (255) it will mow as many outlines as possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added per-area outline count configuration capability, allowing customization of coverage planning parameters for individual mowing areas. When not specified, the global configuration value is used as a fallback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/287)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->