### PR TITLE
More area overrides and `map.bag` conversion fix

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/AreaRecordingBehavior.cpp
@@ -14,6 +14,8 @@
 //
 #include "AreaRecordingBehavior.h"
 
+#include <limits>
+
 extern ros::ServiceClient dockingPointClient;
 extern ros::ServiceClient emergencyClient;
 extern actionlib::SimpleActionClient<mbf_msgs::MoveBaseAction>* mbfClient;
@@ -126,6 +128,11 @@ Behavior* AreaRecordingBehavior::execute() {
       mower_map::AddMowingAreaSrv srv;
       srv.request.isNavigationArea = !is_mowing_area;
       srv.request.area = result;
+      srv.request.area.active = true;
+      srv.request.area.angle = std::numeric_limits<double>::quiet_NaN();
+      srv.request.area.outline_count = -1;
+      srv.request.area.outline_overlap_count = -1;
+      srv.request.area.outline_offset = std::numeric_limits<double>::quiet_NaN();
       if (add_mowing_area_client.call(srv)) {
         ROS_INFO_STREAM("Area added successfully");
       } else {

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -155,7 +155,7 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
     return false;
   }
 
-  if (mapSrv.response.area.area.points.empty()) {
+  if (!mapSrv.response.area.active) {
     ROS_INFO_STREAM("MowingBehavior: Skipping inactive mowing area");
     return true;
   }

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -211,7 +211,7 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
   pathSrv.request.outline = area.area;
   pathSrv.request.holes = area.obstacles;
   pathSrv.request.fill_type = slic3r_coverage_planner::PlanPathRequest::FILL_LINEAR;
-  pathSrv.request.outer_offset = overrideOrGlobal(area.outline_offset, config.outline_offset, -1.0);
+  pathSrv.request.outer_offset = std::isnan(area.outline_offset) ? config.outline_offset : area.outline_offset;
   pathSrv.request.distance = config.tool_width;
   if (!pathClient.call(pathSrv)) {
     ROS_ERROR_STREAM("MowingBehavior: Error during coverage planning");

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -191,15 +191,20 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
   }
 
   // calculate coverage
+  const auto& area = mapSrv.response.area;
+  auto overrideOrGlobal = [](auto override, auto global, auto sentinel) {
+    return (override != sentinel) ? override : global;
+  };
+
   slic3r_coverage_planner::PlanPath pathSrv;
   pathSrv.request.angle = angle;
-  pathSrv.request.outline_count =
-      (mapSrv.response.area.outline_count >= 0) ? mapSrv.response.area.outline_count : config.outline_count;
-  pathSrv.request.outline_overlap_count = config.outline_overlap_count;
-  pathSrv.request.outline = mapSrv.response.area.area;
-  pathSrv.request.holes = mapSrv.response.area.obstacles;
+  pathSrv.request.outline_count = overrideOrGlobal(area.outline_count, config.outline_count, -1);
+  pathSrv.request.outline_overlap_count =
+      overrideOrGlobal(area.outline_overlap_count, config.outline_overlap_count, -1);
+  pathSrv.request.outline = area.area;
+  pathSrv.request.holes = area.obstacles;
   pathSrv.request.fill_type = slic3r_coverage_planner::PlanPathRequest::FILL_LINEAR;
-  pathSrv.request.outer_offset = config.outline_offset;
+  pathSrv.request.outer_offset = overrideOrGlobal(area.outline_offset, config.outline_offset, -1.0);
   pathSrv.request.distance = config.tool_width;
   if (!pathClient.call(pathSrv)) {
     ROS_ERROR_STREAM("MowingBehavior: Error during coverage planning");

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -173,7 +173,7 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
         tf2::Vector3 second(point.x, point.y, 0);
         auto diff = second - first;
         if (diff.length() > 2.0) {
-          // we have found a point that has a distance of > 1 m, calculate the angle
+          // we have found a point that has a distance of > 2 m, calculate the angle
           angle = atan2(diff.y(), diff.x());
           ROS_INFO_STREAM("MowingBehavior: Detected mow angle: " << angle);
           break;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -160,19 +160,24 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
     return true;
   }
 
-  // Area orientation is the same as the first point
+  // Area orientation is the same as the first point, unless explicitly specified in the area attributes
   double angle = 0;
-  auto points = mapSrv.response.area.area.points;
-  if (points.size() >= 2) {
-    tf2::Vector3 first(points[0].x, points[0].y, 0);
-    for (auto point : points) {
-      tf2::Vector3 second(point.x, point.y, 0);
-      auto diff = second - first;
-      if (diff.length() > 2.0) {
-        // we have found a point that has a distance of > 1 m, calculate the angle
-        angle = atan2(diff.y(), diff.x());
-        ROS_INFO_STREAM("MowingBehavior: Detected mow angle: " << angle);
-        break;
+  if (mapSrv.response.area.angle >= 0.0) {
+    angle = mapSrv.response.area.angle;
+    ROS_INFO_STREAM("MowingBehavior: Using explicitly specified mow angle: " << angle);
+  } else {
+    auto points = mapSrv.response.area.area.points;
+    if (points.size() >= 2) {
+      tf2::Vector3 first(points[0].x, points[0].y, 0);
+      for (auto point : points) {
+        tf2::Vector3 second(point.x, point.y, 0);
+        auto diff = second - first;
+        if (diff.length() > 2.0) {
+          // we have found a point that has a distance of > 1 m, calculate the angle
+          angle = atan2(diff.y(), diff.x());
+          ROS_INFO_STREAM("MowingBehavior: Detected mow angle: " << angle);
+          break;
+        }
       }
     }
   }

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -21,6 +21,8 @@
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 
+#include <cmath>
+
 #include "mower_logic/CheckPoint.h"
 #include "mower_map/ClearNavPointSrv.h"
 #include "mower_map/GetMowingAreaSrv.h"
@@ -162,7 +164,7 @@ bool MowingBehavior::create_mowing_plan(int area_index) {
 
   // Area orientation is the same as the first point, unless explicitly specified in the area attributes
   double angle = 0;
-  if (mapSrv.response.area.angle >= 0.0) {
+  if (!std::isnan(mapSrv.response.area.angle)) {
     angle = mapSrv.response.area.angle;
     ROS_INFO_STREAM("MowingBehavior: Using explicitly specified mow angle: " << angle);
   } else {

--- a/src/mower_map/CMakeLists.txt
+++ b/src/mower_map/CMakeLists.txt
@@ -61,6 +61,7 @@ find_package(catkin REQUIRED
 add_message_files(
         FILES
         MapArea.msg
+        MapAreaLegacy.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -2,7 +2,7 @@ string name
 bool active
 geometry_msgs/Polygon area
 geometry_msgs/Polygon[] obstacles
-float64 angle                # per-area override (radians); -1.0 means use the auto-detected polygon angle
+float64 angle                # per-area override (radians); NaN means use the auto-detected polygon angle
 int32 outline_count          # per-area override; -1 means use the global config value
 int32 outline_overlap_count  # per-area override; -1 means use the global config value
 float64 outline_offset       # per-area override; -1.0 means use the global config value

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -1,6 +1,7 @@
 string name
 geometry_msgs/Polygon area
 geometry_msgs/Polygon[] obstacles
+float64 angle                # per-area override (radians); -1.0 means use the auto-detected polygon angle
 int32 outline_count          # per-area override; -1 means use the global config value
 int32 outline_overlap_count  # per-area override; -1 means use the global config value
 float64 outline_offset       # per-area override; -1.0 means use the global config value

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -1,4 +1,5 @@
 string name
+bool active
 geometry_msgs/Polygon area
 geometry_msgs/Polygon[] obstacles
 float64 angle                # per-area override (radians); -1.0 means use the auto-detected polygon angle

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -1,4 +1,6 @@
 string name
 geometry_msgs/Polygon area
 geometry_msgs/Polygon[] obstacles
-int32 outline_count  # per-area override; -1 means use the global config value
+int32 outline_count          # per-area override; -1 means use the global config value
+int32 outline_overlap_count  # per-area override; -1 means use the global config value
+float64 outline_offset       # per-area override; -1.0 means use the global config value

--- a/src/mower_map/msg/MapArea.msg
+++ b/src/mower_map/msg/MapArea.msg
@@ -5,4 +5,4 @@ geometry_msgs/Polygon[] obstacles
 float64 angle                # per-area override (radians); NaN means use the auto-detected polygon angle
 int32 outline_count          # per-area override; -1 means use the global config value
 int32 outline_overlap_count  # per-area override; -1 means use the global config value
-float64 outline_offset       # per-area override; -1.0 means use the global config value
+float64 outline_offset       # per-area override; NaN means use the global config value

--- a/src/mower_map/msg/MapAreaLegacy.msg
+++ b/src/mower_map/msg/MapAreaLegacy.msg
@@ -1,0 +1,6 @@
+# The message in this exact shape has been persisted in legacy map.bag files.
+# It can't be changed without breaking conversion to JSON, so we save this copy for reading the .bag
+# and use an extended MapArea.msg for internal communication.
+string name
+geometry_msgs/Polygon area
+geometry_msgs/Polygon[] obstacles

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -667,32 +667,36 @@ bool clearMap(mower_map::ClearMapSrvRequest& req, mower_map::ClearMapSrvResponse
  * @param topic_name The topic name to query (e.g. "mowing_areas" or "navigation_areas")
  * @param area_type The type to assign to the converted areas (e.g. "mow" or "nav")
  */
-void convertLegacyAreas(rosbag::Bag& bag, const std::string& topic_name, const std::string& area_type) {
+bool convertLegacyAreas(rosbag::Bag& bag, const std::string& topic_name, const std::string& area_type) {
   rosbag::View view(bag, rosbag::TopicQuery(topic_name));
   for (rosbag::MessageInstance const m : view) {
     auto area = m.instantiate<mower_map::MapArea>();
-    if (area) {
-      // Convert main area
-      MapArea main_area;
-      main_area.id = generateNanoId();
-      main_area.name = area->name;
-      main_area.type = area_type;
-      main_area.active = true;
-      main_area.outline = geometryPolygonToInternal(area->area);
-      map_data.areas.push_back(main_area);
+    if (!area) {
+      ROS_ERROR_STREAM("Type mismatch on topic '" << topic_name << "' (got " << m.getDataType()
+                                                  << " / md5=" << m.getMD5Sum() << "), aborting conversion");
+      return false;
+    }
+    // Convert main area
+    MapArea main_area;
+    main_area.id = generateNanoId();
+    main_area.name = area->name;
+    main_area.type = area_type;
+    main_area.active = true;
+    main_area.outline = geometryPolygonToInternal(area->area);
+    map_data.areas.push_back(main_area);
 
-      // Convert obstacles as separate areas
-      for (const auto& obstacle : area->obstacles) {
-        MapArea obs_area;
-        obs_area.id = generateNanoId();
-        obs_area.name = "";
-        obs_area.type = "obstacle";
-        obs_area.active = true;
-        obs_area.outline = geometryPolygonToInternal(obstacle);
-        map_data.areas.push_back(obs_area);
-      }
+    // Convert obstacles as separate areas
+    for (const auto& obstacle : area->obstacles) {
+      MapArea obs_area;
+      obs_area.id = generateNanoId();
+      obs_area.name = "";
+      obs_area.type = "obstacle";
+      obs_area.active = true;
+      obs_area.outline = geometryPolygonToInternal(obstacle);
+      map_data.areas.push_back(obs_area);
     }
   }
+  return true;
 }
 
 void convertLegacyMapToJson() {
@@ -709,31 +713,39 @@ void convertLegacyMapToJson() {
   map_data.clear();
 
   // Read mowing and navigation areas
-  convertLegacyAreas(bag, "mowing_areas", "mow");
-  convertLegacyAreas(bag, "navigation_areas", "nav");
+  if (!convertLegacyAreas(bag, "mowing_areas", "mow") || !convertLegacyAreas(bag, "navigation_areas", "nav")) {
+    bag.close();
+    map_data.clear();
+    return;
+  }
 
   // Read docking point
   {
     rosbag::View view(bag, rosbag::TopicQuery("docking_point"));
     for (rosbag::MessageInstance const m : view) {
       auto pt = m.instantiate<geometry_msgs::Pose>();
-      if (pt) {
-        // Convert quaternion to yaw
-        tf2::Quaternion q;
-        tf2::fromMsg(pt->orientation, q);
-        tf2::Matrix3x3 m(q);
-        double unused1, unused2, yaw;
-        m.getRPY(unused1, unused2, yaw);
-
-        // Create docking station
-        DockingStation ds;
-        ds.id = generateNanoId();
-        ds.name = "Docking Station";
-        ds.active = true;
-        ds.position = {pt->position.x, pt->position.y};
-        ds.heading = yaw;
-        map_data.docking_stations.push_back(ds);
+      if (!pt) {
+        ROS_ERROR_STREAM("Type mismatch on topic 'docking_point' (got " << m.getDataType() << " / md5=" << m.getMD5Sum()
+                                                                        << "), aborting conversion");
+        bag.close();
+        map_data.clear();
+        return;
       }
+      // Convert quaternion to yaw
+      tf2::Quaternion q;
+      tf2::fromMsg(pt->orientation, q);
+      tf2::Matrix3x3 rot(q);
+      double unused1, unused2, yaw;
+      rot.getRPY(unused1, unused2, yaw);
+
+      // Create docking station
+      DockingStation ds;
+      ds.id = generateNanoId();
+      ds.name = "Docking Station";
+      ds.active = true;
+      ds.position = {pt->position.x, pt->position.y};
+      ds.heading = yaw;
+      map_data.docking_stations.push_back(ds);
     }
   }
 

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -75,6 +75,7 @@ struct MapArea {
   std::string type;
   bool active;
   Polygon outline;
+  double angle = -1.0;
   int outline_count = -1;
   int outline_overlap_count = -1;
   double outline_offset = -1.0;
@@ -117,6 +118,7 @@ void to_json(json& j, const MapArea& data) {
   if (!data.name.empty()) properties["name"] = data.name;
   properties["type"] = data.type;
   if (!data.active) properties["active"] = data.active;
+  if (data.angle >= 0.0) properties["angle"] = data.angle;
   if (data.outline_count >= 0) properties["outline_count"] = data.outline_count;
   if (data.outline_overlap_count >= 0) properties["outline_overlap_count"] = data.outline_overlap_count;
   if (data.outline_offset >= 0.0) properties["outline_offset"] = data.outline_offset;
@@ -130,6 +132,7 @@ void from_json(const json& j, MapArea& data) {
   data.name = properties.value("name", "");
   data.type = properties.value("type", "draft");
   data.active = properties.value("active", true);
+  data.angle = properties.value("angle", -1.0);
   data.outline_count = properties.value("outline_count", -1);
   data.outline_overlap_count = properties.value("outline_overlap_count", -1);
   data.outline_offset = properties.value("outline_offset", -1.0);
@@ -255,6 +258,7 @@ MapArea mowerMapAreaToInternal(const geometry_msgs::Polygon& area, const std::st
 mower_map::MapArea internalMapAreaToMower(const MapArea& area) {
   mower_map::MapArea result;
   result.name = area.name;
+  result.angle = area.angle;
   result.outline_count = area.outline_count;
   result.outline_overlap_count = area.outline_overlap_count;
   result.outline_offset = area.outline_offset;

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -82,7 +82,7 @@ struct MapArea {
   double angle = std::numeric_limits<double>::quiet_NaN();
   int outline_count = -1;
   int outline_overlap_count = -1;
-  double outline_offset = -1.0;
+  double outline_offset = std::numeric_limits<double>::quiet_NaN();
 };
 
 struct DockingStation {
@@ -125,7 +125,7 @@ void to_json(json& j, const MapArea& data) {
   if (!std::isnan(data.angle)) properties["angle"] = data.angle;
   if (data.outline_count >= 0) properties["outline_count"] = data.outline_count;
   if (data.outline_overlap_count >= 0) properties["outline_overlap_count"] = data.outline_overlap_count;
-  if (data.outline_offset >= 0.0) properties["outline_offset"] = data.outline_offset;
+  if (!std::isnan(data.outline_offset)) properties["outline_offset"] = data.outline_offset;
   j["properties"] = properties;
   j["outline"] = data.outline;
 }
@@ -139,7 +139,7 @@ void from_json(const json& j, MapArea& data) {
   data.angle = properties.value("angle", std::numeric_limits<double>::quiet_NaN());
   data.outline_count = properties.value("outline_count", -1);
   data.outline_overlap_count = properties.value("outline_overlap_count", -1);
-  data.outline_offset = properties.value("outline_offset", -1.0);
+  data.outline_offset = properties.value("outline_offset", std::numeric_limits<double>::quiet_NaN());
   j.at("outline").get_to(data.outline);
 }
 

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -244,15 +244,31 @@ geometry_msgs::Polygon internalPolygonToGeometry(const Polygon& poly) {
 }
 
 /**
+ * Convert a geometry_msgs::Polygon obstacle to our internal MapArea struct
+ */
+MapArea obstacleToInternal(const geometry_msgs::Polygon& obstacle) {
+  MapArea result;
+  result.id = generateNanoId();
+  result.type = "obstacle";
+  result.active = true;
+  result.outline = geometryPolygonToInternal(obstacle);
+  return result;
+}
+
+/**
  * Convert a mower_map::MapArea to our internal MapArea struct
  */
-MapArea mowerMapAreaToInternal(const geometry_msgs::Polygon& area, const std::string& type, const std::string& name) {
+MapArea mowerMapAreaToInternal(const mower_map::MapArea& area, const std::string& type) {
   MapArea result;
   result.id = generateNanoId();
   result.type = type;
-  result.name = name;
-  result.active = true;
-  result.outline = geometryPolygonToInternal(area);
+  result.name = area.name;
+  result.active = area.active;
+  result.angle = area.angle;
+  result.outline_count = area.outline_count;
+  result.outline_overlap_count = area.outline_overlap_count;
+  result.outline_offset = area.outline_offset;
+  result.outline = geometryPolygonToInternal(area.area);
   return result;
 }
 
@@ -558,9 +574,9 @@ void readMapFromFile() {
 bool addMowingArea(mower_map::AddMowingAreaSrvRequest& req, mower_map::AddMowingAreaSrvResponse& res) {
   ROS_INFO_STREAM("Got addMowingArea call");
 
-  map_data.areas.push_back(mowerMapAreaToInternal(req.area.area, req.isNavigationArea ? "nav" : "mow", req.area.name));
+  map_data.areas.push_back(mowerMapAreaToInternal(req.area, req.isNavigationArea ? "nav" : "mow"));
   for (const auto& obstacle : req.area.obstacles) {
-    map_data.areas.push_back(mowerMapAreaToInternal(obstacle, "obstacle", ""));
+    map_data.areas.push_back(obstacleToInternal(obstacle));
   }
 
   saveMapToFile();

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -12,6 +12,9 @@
 // You should have received a copy of the GNU General Public License along with OpenMower. If not, see
 // <https://www.gnu.org/licenses/>.
 //
+#include <cmath>
+#include <limits>
+
 #include "grid_map_cv/GridMapCvConverter.hpp"
 #include "grid_map_ros/GridMapRosConverter.hpp"
 #include "grid_map_ros/PolygonRosConverter.hpp"
@@ -76,7 +79,7 @@ struct MapArea {
   std::string type;
   bool active;
   Polygon outline;
-  double angle = -1.0;
+  double angle = std::numeric_limits<double>::quiet_NaN();
   int outline_count = -1;
   int outline_overlap_count = -1;
   double outline_offset = -1.0;
@@ -119,7 +122,7 @@ void to_json(json& j, const MapArea& data) {
   if (!data.name.empty()) properties["name"] = data.name;
   properties["type"] = data.type;
   if (!data.active) properties["active"] = data.active;
-  if (data.angle >= 0.0) properties["angle"] = data.angle;
+  if (!std::isnan(data.angle)) properties["angle"] = data.angle;
   if (data.outline_count >= 0) properties["outline_count"] = data.outline_count;
   if (data.outline_overlap_count >= 0) properties["outline_overlap_count"] = data.outline_overlap_count;
   if (data.outline_offset >= 0.0) properties["outline_offset"] = data.outline_offset;
@@ -133,7 +136,7 @@ void from_json(const json& j, MapArea& data) {
   data.name = properties.value("name", "");
   data.type = properties.value("type", "draft");
   data.active = properties.value("active", true);
-  data.angle = properties.value("angle", -1.0);
+  data.angle = properties.value("angle", std::numeric_limits<double>::quiet_NaN());
   data.outline_count = properties.value("outline_count", -1);
   data.outline_overlap_count = properties.value("outline_overlap_count", -1);
   data.outline_offset = properties.value("outline_offset", -1.0);

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -246,11 +246,11 @@ geometry_msgs::Polygon internalPolygonToGeometry(const Polygon& poly) {
 /**
  * Convert a geometry_msgs::Polygon obstacle to our internal MapArea struct
  */
-MapArea obstacleToInternal(const geometry_msgs::Polygon& obstacle) {
+MapArea obstacleToInternal(const geometry_msgs::Polygon& obstacle, bool active) {
   MapArea result;
   result.id = generateNanoId();
   result.type = "obstacle";
-  result.active = true;
+  result.active = active;
   result.outline = geometryPolygonToInternal(obstacle);
   return result;
 }
@@ -576,7 +576,7 @@ bool addMowingArea(mower_map::AddMowingAreaSrvRequest& req, mower_map::AddMowing
 
   map_data.areas.push_back(mowerMapAreaToInternal(req.area, req.isNavigationArea ? "nav" : "mow"));
   for (const auto& obstacle : req.area.obstacles) {
-    map_data.areas.push_back(obstacleToInternal(obstacle));
+    map_data.areas.push_back(obstacleToInternal(obstacle, req.area.active));
   }
 
   saveMapToFile();

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -76,6 +76,8 @@ struct MapArea {
   bool active;
   Polygon outline;
   int outline_count = -1;
+  int outline_overlap_count = -1;
+  double outline_offset = -1.0;
 };
 
 struct DockingStation {
@@ -116,6 +118,8 @@ void to_json(json& j, const MapArea& data) {
   properties["type"] = data.type;
   if (!data.active) properties["active"] = data.active;
   if (data.outline_count >= 0) properties["outline_count"] = data.outline_count;
+  if (data.outline_overlap_count >= 0) properties["outline_overlap_count"] = data.outline_overlap_count;
+  if (data.outline_offset >= 0.0) properties["outline_offset"] = data.outline_offset;
   j["properties"] = properties;
   j["outline"] = data.outline;
 }
@@ -127,6 +131,8 @@ void from_json(const json& j, MapArea& data) {
   data.type = properties.value("type", "draft");
   data.active = properties.value("active", true);
   data.outline_count = properties.value("outline_count", -1);
+  data.outline_overlap_count = properties.value("outline_overlap_count", -1);
+  data.outline_offset = properties.value("outline_offset", -1.0);
   j.at("outline").get_to(data.outline);
 }
 
@@ -250,6 +256,8 @@ mower_map::MapArea internalMapAreaToMower(const MapArea& area) {
   mower_map::MapArea result;
   result.name = area.name;
   result.outline_count = area.outline_count;
+  result.outline_overlap_count = area.outline_overlap_count;
+  result.outline_offset = area.outline_offset;
   // Leave area empty if it is not active
   if (area.active) {
     result.area = internalPolygonToGeometry(area.outline);

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -259,14 +259,12 @@ MapArea mowerMapAreaToInternal(const geometry_msgs::Polygon& area, const std::st
 mower_map::MapArea internalMapAreaToMower(const MapArea& area) {
   mower_map::MapArea result;
   result.name = area.name;
+  result.active = area.active;
   result.angle = area.angle;
   result.outline_count = area.outline_count;
   result.outline_overlap_count = area.outline_overlap_count;
   result.outline_offset = area.outline_offset;
-  // Leave area empty if it is not active
-  if (area.active) {
-    result.area = internalPolygonToGeometry(area.outline);
-  }
+  result.area = internalPolygonToGeometry(area.outline);
   return result;
 }
 

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -27,6 +27,7 @@
 #include "geometry_msgs/Point32.h"
 #include "geometry_msgs/Polygon.h"
 #include "mower_map/MapArea.h"
+#include "mower_map/MapAreaLegacy.h"
 
 // Include Service Messages
 #include "mower_map/AddMowingAreaSrv.h"
@@ -670,7 +671,7 @@ bool clearMap(mower_map::ClearMapSrvRequest& req, mower_map::ClearMapSrvResponse
 bool convertLegacyAreas(rosbag::Bag& bag, const std::string& topic_name, const std::string& area_type) {
   rosbag::View view(bag, rosbag::TopicQuery(topic_name));
   for (rosbag::MessageInstance const m : view) {
-    auto area = m.instantiate<mower_map::MapArea>();
+    auto area = m.instantiate<mower_map::MapAreaLegacy>();
     if (!area) {
       ROS_ERROR_STREAM("Type mismatch on topic '" << topic_name << "' (got " << m.getDataType()
                                                   << " / md5=" << m.getMD5Sum() << "), aborting conversion");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Area-level active flag to include/exclude areas from mowing plans
  * Per-area overrides for mowing angle, outline counts, and outer offset, with automatic angle detection when unspecified

* **Improvements**
  * Map format extended with new per-area fields while retaining legacy map support for compatibility
  * JSON/legacy map import made more robust with stricter validation and safer conversion handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/288)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->