### PR TITLE
Add opt-in telemetry and crash reporting via Sentry

### DIFF
--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -333,6 +333,29 @@ export OM_RAIN_DELAY_MINUTES=30
 # export OM_SNAPSHOT_DURATION=1200
 
 
+################################
+##    Telemetry / Analytics   ##
+################################
+
+# Anonymous telemetry — helps the OpenMower project ship stable releases faster.
+#
+# Enabling this sends crash reports and anonymous usage events (mow start/stop,
+# docking, emergencies, software version, hardware platform) to the OpenMower
+# developers. NO GPS or location data is ever collected.
+#
+# Crash and exception reports help fix bugs quickly. Version stability data lets
+# us see which releases are running reliably in the field and cut stable releases
+# more often.
+#
+# Without a setting the software prints a reminder on every start until you decide.
+#
+# To opt in:
+# export OM_TELEMETRY_ENABLE=true
+#
+# To opt out silently:
+# export OM_TELEMETRY_ENABLE=false
+#
+
 # source the default values for the hardware platform.
 # you only need this line on non-docker installs. in the docker, it will be done automatically.
 # source $(rospack find open_mower)/params/hardware_specific/$OM_MOWER/default_environment.sh

--- a/config/mower_config.sh.example
+++ b/config/mower_config.sh.example
@@ -341,6 +341,29 @@ export OM_RAIN_DELAY_MINUTES=30
 # export OM_SNAPSHOT_DURATION=1200
 
 
+################################
+##    Telemetry / Analytics   ##
+################################
+
+# Anonymous telemetry — helps the OpenMower project ship stable releases faster.
+#
+# Enabling this sends crash reports and anonymous usage events (mow start/stop,
+# docking, emergencies, software version, hardware platform) to the OpenMower
+# developers. NO GPS or location data is ever collected.
+#
+# Crash and exception reports help fix bugs quickly. Version stability data lets
+# us see which releases are running reliably in the field and cut stable releases
+# more often.
+#
+# Without a setting the software prints a reminder on every start until you decide.
+#
+# To opt in:
+# export OM_TELEMETRY_ENABLE=true
+#
+# To opt out silently:
+# export OM_TELEMETRY_ENABLE=false
+#
+
 # source the default values for the hardware platform.
 # you only need this line on non-docker installs. in the docker, it will be done automatically.
 # source $(rospack find open_mower)/params/hardware_specific/$OM_MOWER/default_environment.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN rosdep install --from-paths src --ignore-src --simulate | \
     sed --expression '1d' | sort | tr -d '\n' | sed --expression 's/  apt-get install//g' > apt-install_list && \
     apt-get update && apt-get install --no-install-recommends --yes $(cat apt-install_list) libasio-dev && \
     rm -rf /var/lib/apt/lists/* apt-install_list
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make"
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
 
 ####################################################################################################
 
@@ -68,7 +68,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo \"v0.0.0\")" > version_info.env
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,8 +40,8 @@ RUN rosdep install --from-paths src --ignore-src --simulate | \
     sed --expression '1d' | sort | tr -d '\n' | sed --expression 's/  apt-get install//g' > apt-install_list && \
     apt-get update && apt-get install --no-install-recommends --yes $(cat apt-install_list) libasio-dev && \
     rm -rf /var/lib/apt/lists/* apt-install_list
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make"
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
 
 ####################################################################################################
 
@@ -82,7 +82,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo \"v0.0.0\")" > version_info.env
 

--- a/docker/Dockerfile.Legacy
+++ b/docker/Dockerfile.Legacy
@@ -35,8 +35,8 @@ RUN rosdep install --from-paths src --ignore-src --simulate | \
     sed --expression '1d' | sort | tr -d '\n' | sed --expression 's/  apt-get install//g' > apt-install_list && \
     apt-get update && apt-get install --no-install-recommends --yes $(cat apt-install_list) libasio-dev && \
     rm -rf /var/lib/apt/lists/* apt-install_list
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make"
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
 
 ####################################################################################################
 
@@ -80,7 +80,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo "v0.0.0")" > version_info.env
 

--- a/docker/Dockerfile.Legacy
+++ b/docker/Dockerfile.Legacy
@@ -48,8 +48,8 @@ RUN rosdep install --from-paths src --ignore-src --simulate | \
     sed --expression '1d' | sort | tr -d '\n' | sed --expression 's/  apt-get install//g' > apt-install_list && \
     apt-get update && apt-get install --no-install-recommends --yes $(cat apt-install_list) libasio-dev && \
     rm -rf /var/lib/apt/lists/* apt-install_list
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make"
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && source /opt/slic3r_coverage_planner_workspace/devel/setup.bash && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/opt/prebuilt/slic3r_coverage_planner install"
 
 ####################################################################################################
 
@@ -94,7 +94,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo "v0.0.0")" > version_info.env
 

--- a/docker/openmower_entrypoint.sh
+++ b/docker/openmower_entrypoint.sh
@@ -8,6 +8,9 @@ source /opt/open_mower_ros/devel/setup.bash
 # setup om environment
 source /opt/open_mower_ros/version_info.env
 
+# Default Sentry DSN — override via OM_SENTRY_DSN in mower_config.sh if needed
+export OM_SENTRY_DSN="${OM_SENTRY_DSN:-https://f7f63872866cd6820e54cb019a620033@o4511382750887936.ingest.de.sentry.io/4511382758228048}"
+
 # OSv2 debugging get controlled via env var DEBUG and has the ROSCONSOLE_CONFIG_FILE embedded
 shopt -s nocasematch
 case "${DEBUG:-0}" in

--- a/src/mower_analytics/CMakeLists.txt
+++ b/src/mower_analytics/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.14)
+project(mower_analytics)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  mower_msgs
+)
+
+include(FetchContent)
+
+FetchContent_Declare(sentry-native
+  GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
+  GIT_TAG        0.14.0
+  GIT_SUBMODULES "external/crashpad"
+)
+set(SENTRY_BACKEND   "crashpad" CACHE STRING "" FORCE)
+set(SENTRY_TRANSPORT "curl"     CACHE STRING "" FORCE)
+FetchContent_MakeAvailable(sentry-native)
+
+add_library(mower_analytics_sentry src/sentry_guard.cpp)
+target_include_directories(mower_analytics_sentry PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(mower_analytics_sentry PUBLIC sentry::sentry ${catkin_LIBRARIES})
+set_target_properties(mower_analytics_sentry PROPERTIES CXX_STANDARD 17)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES mower_analytics_sentry
+  CATKIN_DEPENDS roscpp
+)
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+# crashpad_handler must be findable at runtime — place it in this package's bin dir
+# so SentryGuard's sibling-path lookup resolves it for all other nodes too.
+add_custom_command(TARGET mower_analytics_sentry POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+    ${CATKIN_DEVEL_PREFIX}/lib/mower_analytics
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:crashpad_handler>
+    ${CATKIN_DEVEL_PREFIX}/lib/mower_analytics/crashpad_handler
+  COMMENT "Copying crashpad_handler to devel/lib/mower_analytics/"
+)

--- a/src/mower_analytics/include/mower_analytics/sentry_guard.h
+++ b/src/mower_analytics/include/mower_analytics/sentry_guard.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <map>
+#include <string>
+
+namespace mower_analytics {
+
+enum class Level { Info, Warning, Error };
+
+// RAII wrapper for sentry init/close. Construct once in main() after ros::init().
+// Reads OM_TELEMETRY_ENABLE, OM_SENTRY_DSN, OM_SOFTWARE_VERSION, HARDWARE_PLATFORM from env.
+// Prints a ROS_WARN when OM_TELEMETRY_ENABLE is unset so users know they must decide.
+// No-op when telemetry is disabled or DSN is unset — safe to use unconditionally.
+class SentryGuard {
+ public:
+  explicit SentryGuard(const std::string& node_name);
+  ~SentryGuard();
+
+  SentryGuard(const SentryGuard&) = delete;
+  SentryGuard& operator=(const SentryGuard&) = delete;
+
+  bool enabled() const {
+    return enabled_;
+  }
+
+  // Call from anywhere after SentryGuard is constructed in main().
+  // No-ops if telemetry is disabled.
+  static void captureEvent(Level level, const std::string& message,
+                           const std::map<std::string, std::string>& extra = {});
+
+  static void addBreadcrumb(const std::string& message, const std::string& category = "openmower");
+
+ private:
+  bool enabled_{false};
+};
+
+}  // namespace mower_analytics

--- a/src/mower_analytics/package.xml
+++ b/src/mower_analytics/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mower_analytics</name>
+  <version>0.0.1</version>
+  <description>OpenMower telemetry — opt-in usage and crash tracking via Sentry</description>
+  <maintainer email="clemens@undef.de">Clemens Elflein</maintainer>
+  <license>GPL-3.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>mower_msgs</depend>
+</package>

--- a/src/mower_analytics/src/sentry_guard.cpp
+++ b/src/mower_analytics/src/sentry_guard.cpp
@@ -3,11 +3,14 @@
 #include <sentry.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
 
 namespace mower_analytics {
+
+static std::atomic<bool> s_initialized{false};
 
 static std::string getenv_or(const char* name, const std::string& fallback = "") {
   const char* v = std::getenv(name);
@@ -104,16 +107,21 @@ SentryGuard::SentryGuard(const std::string& node_name) {
   sentry_set_tag("node", node_name.c_str());
 
   enabled_ = true;
+  s_initialized = true;
   ROS_INFO_STREAM("[analytics] Sentry active for " << node_name << " (release=" << release << ")");
   captureEvent(Level::Info, "node.started", {{"node", node_name}, {"release", release}});
 }
 
 SentryGuard::~SentryGuard() {
-  if (enabled_) sentry_close();
+  if (enabled_) {
+    s_initialized = false;
+    sentry_close();
+  }
 }
 
 void SentryGuard::captureEvent(Level level, const std::string& message,
                                const std::map<std::string, std::string>& extra) {
+  if (!s_initialized) return;
   sentry_value_t event = sentry_value_new_message_event(toSentryLevel(level), "openmower", message.c_str());
 
   if (!extra.empty()) {
@@ -128,6 +136,7 @@ void SentryGuard::captureEvent(Level level, const std::string& message,
 }
 
 void SentryGuard::addBreadcrumb(const std::string& message, const std::string& category) {
+  if (!s_initialized) return;
   sentry_value_t crumb = sentry_value_new_breadcrumb("default", message.c_str());
   sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category.c_str()));
   sentry_add_breadcrumb(crumb);

--- a/src/mower_analytics/src/sentry_guard.cpp
+++ b/src/mower_analytics/src/sentry_guard.cpp
@@ -30,9 +30,12 @@ static bool isTelemetryDisabled(const std::string& val) {
 }
 
 static std::string findHandlerPath() {
-  std::filesystem::path exe_dir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  std::error_code ec;
+  std::filesystem::path exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec) return "";
+  std::filesystem::path exe_dir = exe.parent_path();
   auto candidate = exe_dir / "crashpad_handler";
-  if (std::filesystem::exists(candidate)) return candidate.string();
+  if (std::filesystem::exists(candidate, ec) && !ec) return candidate.string();
   return (exe_dir.parent_path() / "mower_analytics" / "crashpad_handler").string();
 }
 
@@ -80,8 +83,13 @@ SentryGuard::SentryGuard(const std::string& node_name) {
   sentry_options_set_dsn(options, dsn.c_str());
   sentry_options_set_release(options, release.c_str());
   const std::string handler = findHandlerPath();
-  ROS_INFO_STREAM("[analytics] crashpad_handler: "
-                  << handler << (std::filesystem::exists(handler) ? "" : " (NOT FOUND — crash reports disabled)"));
+  if (handler.empty()) {
+    ROS_WARN_STREAM("[analytics] crashpad_handler: could not resolve exe path — crash reports disabled");
+  } else {
+    std::error_code ec;
+    bool found = std::filesystem::exists(handler, ec) && !ec;
+    ROS_INFO_STREAM("[analytics] crashpad_handler: " << handler << (found ? "" : " (NOT FOUND — crash reports disabled)"));
+  }
   sentry_options_set_handler_path(options, handler.c_str());
   const std::string ros_home = getenv_or("ROS_HOME", getenv_or("HOME", "/root") + "/.ros");
   sentry_options_set_database_path(options, (ros_home + "/sentry").c_str());

--- a/src/mower_analytics/src/sentry_guard.cpp
+++ b/src/mower_analytics/src/sentry_guard.cpp
@@ -6,11 +6,13 @@
 #include <atomic>
 #include <cstdlib>
 #include <filesystem>
+#include <shared_mutex>
 #include <string>
 
 namespace mower_analytics {
 
 static std::atomic<bool> s_initialized{false};
+static std::shared_mutex s_sentry_mutex;
 
 static std::string getenv_or(const char* name, const std::string& fallback = "") {
   const char* v = std::getenv(name);
@@ -114,6 +116,7 @@ SentryGuard::SentryGuard(const std::string& node_name) {
 
 SentryGuard::~SentryGuard() {
   if (enabled_) {
+    std::unique_lock lock(s_sentry_mutex);
     s_initialized = false;
     sentry_close();
   }
@@ -121,6 +124,7 @@ SentryGuard::~SentryGuard() {
 
 void SentryGuard::captureEvent(Level level, const std::string& message,
                                const std::map<std::string, std::string>& extra) {
+  std::shared_lock lock(s_sentry_mutex);
   if (!s_initialized) return;
   sentry_value_t event = sentry_value_new_message_event(toSentryLevel(level), "openmower", message.c_str());
 
@@ -136,6 +140,7 @@ void SentryGuard::captureEvent(Level level, const std::string& message,
 }
 
 void SentryGuard::addBreadcrumb(const std::string& message, const std::string& category) {
+  std::shared_lock lock(s_sentry_mutex);
   if (!s_initialized) return;
   sentry_value_t crumb = sentry_value_new_breadcrumb("default", message.c_str());
   sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category.c_str()));

--- a/src/mower_analytics/src/sentry_guard.cpp
+++ b/src/mower_analytics/src/sentry_guard.cpp
@@ -88,13 +88,17 @@ SentryGuard::SentryGuard(const std::string& node_name) {
   } else {
     std::error_code ec;
     bool found = std::filesystem::exists(handler, ec) && !ec;
-    ROS_INFO_STREAM("[analytics] crashpad_handler: " << handler << (found ? "" : " (NOT FOUND — crash reports disabled)"));
+    ROS_INFO_STREAM("[analytics] crashpad_handler: " << handler
+                                                     << (found ? "" : " (NOT FOUND — crash reports disabled)"));
   }
   sentry_options_set_handler_path(options, handler.c_str());
   const std::string ros_home = getenv_or("ROS_HOME", getenv_or("HOME", "/root") + "/.ros");
   sentry_options_set_database_path(options, (ros_home + "/sentry").c_str());
   sentry_options_set_auto_session_tracking(options, 1);
-  sentry_init(options);
+  if (sentry_init(options) != 0) {
+    ROS_ERROR_STREAM("[analytics] sentry_init failed — telemetry disabled for " << node_name);
+    return;
+  }
 
   sentry_set_tag("hardware_platform", hw_platform.c_str());
   sentry_set_tag("node", node_name.c_str());

--- a/src/mower_analytics/src/sentry_guard.cpp
+++ b/src/mower_analytics/src/sentry_guard.cpp
@@ -1,0 +1,124 @@
+#include <mower_analytics/sentry_guard.h>
+#include <ros/ros.h>
+#include <sentry.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace mower_analytics {
+
+static std::string getenv_or(const char* name, const std::string& fallback = "") {
+  const char* v = std::getenv(name);
+  return v ? std::string(v) : fallback;
+}
+
+static std::string toLower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+  return s;
+}
+
+static bool isTelemetryEnabled(const std::string& val) {
+  const std::string v = toLower(val);
+  return v == "true" || v == "1" || v == "yes" || v == "on";
+}
+
+static bool isTelemetryDisabled(const std::string& val) {
+  const std::string v = toLower(val);
+  return v == "false" || v == "0" || v == "no" || v == "off";
+}
+
+static std::string findHandlerPath() {
+  std::filesystem::path exe_dir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  auto candidate = exe_dir / "crashpad_handler";
+  if (std::filesystem::exists(candidate)) return candidate.string();
+  return (exe_dir.parent_path() / "mower_analytics" / "crashpad_handler").string();
+}
+
+static sentry_level_t toSentryLevel(Level level) {
+  switch (level) {
+    case Level::Warning: return SENTRY_LEVEL_WARNING;
+    case Level::Error: return SENTRY_LEVEL_ERROR;
+    default: return SENTRY_LEVEL_INFO;
+  }
+}
+
+SentryGuard::SentryGuard(const std::string& node_name) {
+  const std::string telemetry = getenv_or("OM_TELEMETRY_ENABLE");
+
+  if (telemetry.empty() || (!isTelemetryEnabled(telemetry) && !isTelemetryDisabled(telemetry))) {
+    ROS_WARN_STREAM(
+        "[analytics] ============================================================\n"
+        "[analytics] Anonymous telemetry is not yet enabled.\n"
+        "[analytics]\n"
+        "[analytics] By enabling it you help the OpenMower project:\n"
+        "[analytics]   - Crashes and exceptions are reported automatically,\n"
+        "[analytics]     so bugs get fixed faster.\n"
+        "[analytics]   - We can see which firmware versions are running reliably\n"
+        "[analytics]     in the field and use that to cut stable releases more often.\n"
+        "[analytics]\n"
+        "[analytics] NO location or GPS data is ever collected.\n"
+        "[analytics] Only anonymous data: software version, hardware platform,\n"
+        "[analytics] mow start/stop, docking events, and crash reports.\n"
+        "[analytics]\n"
+        "[analytics] Opt in:  export OM_TELEMETRY_ENABLE=true   (in mower_config.sh)\n"
+        "[analytics] Opt out: export OM_TELEMETRY_ENABLE=false  (silences this message)\n"
+        "[analytics] ============================================================");
+    return;
+  }
+
+  if (!isTelemetryEnabled(telemetry)) return;
+
+  const std::string dsn = getenv_or("OM_SENTRY_DSN");
+  if (dsn.empty()) return;
+
+  const std::string release = getenv_or("OM_SOFTWARE_VERSION", "unknown");
+  const std::string hw_platform = getenv_or("HARDWARE_PLATFORM", "unknown");
+
+  sentry_options_t* options = sentry_options_new();
+  sentry_options_set_dsn(options, dsn.c_str());
+  sentry_options_set_release(options, release.c_str());
+  const std::string handler = findHandlerPath();
+  ROS_INFO_STREAM("[analytics] crashpad_handler: "
+                  << handler << (std::filesystem::exists(handler) ? "" : " (NOT FOUND — crash reports disabled)"));
+  sentry_options_set_handler_path(options, handler.c_str());
+  const std::string ros_home = getenv_or("ROS_HOME", getenv_or("HOME", "/root") + "/.ros");
+  sentry_options_set_database_path(options, (ros_home + "/sentry").c_str());
+  sentry_options_set_auto_session_tracking(options, 1);
+  sentry_init(options);
+
+  sentry_set_tag("hardware_platform", hw_platform.c_str());
+  sentry_set_tag("node", node_name.c_str());
+
+  enabled_ = true;
+  ROS_INFO_STREAM("[analytics] Sentry active for " << node_name << " (release=" << release << ")");
+  captureEvent(Level::Info, "node.started", {{"node", node_name}, {"release", release}});
+}
+
+SentryGuard::~SentryGuard() {
+  if (enabled_) sentry_close();
+}
+
+void SentryGuard::captureEvent(Level level, const std::string& message,
+                               const std::map<std::string, std::string>& extra) {
+  sentry_value_t event = sentry_value_new_message_event(toSentryLevel(level), "openmower", message.c_str());
+
+  if (!extra.empty()) {
+    sentry_value_t extra_obj = sentry_value_new_object();
+    for (const auto& [k, v] : extra) {
+      sentry_value_set_by_key(extra_obj, k.c_str(), sentry_value_new_string(v.c_str()));
+    }
+    sentry_value_set_by_key(event, "extra", extra_obj);
+  }
+
+  sentry_capture_event(event);
+}
+
+void SentryGuard::addBreadcrumb(const std::string& message, const std::string& category) {
+  sentry_value_t crumb = sentry_value_new_breadcrumb("default", message.c_str());
+  sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category.c_str()));
+  sentry_add_breadcrumb(crumb);
+}
+
+}  // namespace mower_analytics

--- a/src/mower_comms_v1/CMakeLists.txt
+++ b/src/mower_comms_v1/CMakeLists.txt
@@ -9,6 +9,7 @@ project(mower_comms_v1)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
+  mower_analytics
   mower_msgs
         sensor_msgs
         roscpp

--- a/src/mower_comms_v1/package.xml
+++ b/src/mower_comms_v1/package.xml
@@ -28,6 +28,7 @@
   <exec_depend>serial</exec_depend>
   <exec_depend>xesc_driver</exec_depend>
   <depend>xesc_msgs</depend>
+  <depend>mower_analytics</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/mower_comms_v1/src/mower_comms.cpp
+++ b/src/mower_comms_v1/src/mower_comms.cpp
@@ -16,6 +16,7 @@
 #include <dynamic_reconfigure/client.h>
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/TwistStamped.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_logic/PowerConfig.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Emergency.h>
@@ -701,6 +702,7 @@ void powerReconfigCB(const ll::PowerConfig& config) {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "mower_comms_v1");
+  mower_analytics::SentryGuard sentry_guard("mower_comms_v1");
 
   sensor_imu_msg.header.seq = 0;
 

--- a/src/mower_comms_v2/CMakeLists.txt
+++ b/src/mower_comms_v2/CMakeLists.txt
@@ -8,6 +8,7 @@ add_compile_options(-std=c++17)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+        mower_analytics
         mower_msgs
         sensor_msgs
         roscpp

--- a/src/mower_comms_v2/package.xml
+++ b/src/mower_comms_v2/package.xml
@@ -23,6 +23,7 @@
     <exec_depend>mower_msgs</exec_depend>
     <exec_depend>roscpp</exec_depend>
     <depend>xesc_msgs</depend>
+    <depend>mower_analytics</depend>
     <depend>nmea_msgs</depend>
     <depend>std_msgs</depend>
 

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -14,6 +14,7 @@
 // <https://www.gnu.org/licenses/>.
 //
 #include <geometry_msgs/TwistStamped.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Emergency.h>
 #include <mower_msgs/EmergencyStopSrv.h>
@@ -120,6 +121,7 @@ static void spdlog_cb(const spdlog::details::log_msg& msg) {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "mower_comms_v2");
+  mower_analytics::SentryGuard sentry_guard("mower_comms_v2");
 
   {
     auto sink = std::make_shared<spdlog::sinks::callback_sink_mt>(spdlog_cb);

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -14,6 +14,7 @@
 // <https://www.gnu.org/licenses/>.
 //
 #include <geometry_msgs/TwistStamped.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Emergency.h>
 #include <mower_msgs/EmergencyStopSrv.h>
@@ -123,6 +124,7 @@ static void spdlog_cb(const spdlog::details::log_msg& msg) {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "mower_comms_v2");
+  mower_analytics::SentryGuard sentry_guard("mower_comms_v2");
 
   {
     auto sink = std::make_shared<spdlog::sinks::callback_sink_mt>(spdlog_cb);

--- a/src/mower_logic/CMakeLists.txt
+++ b/src/mower_logic/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
         dynamic_reconfigure
         ftc_local_planner
         mbf_msgs
+        mower_analytics
         mower_map
         mower_msgs
         nav_msgs

--- a/src/mower_logic/package.xml
+++ b/src/mower_logic/package.xml
@@ -52,6 +52,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>imu_tools</exec_depend>
   <exec_depend>xbot_msgs</exec_depend>
+  <depend>mower_analytics</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/mower_logic/package.xml
+++ b/src/mower_logic/package.xml
@@ -53,6 +53,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>imu_tools</exec_depend>
   <exec_depend>xbot_msgs</exec_depend>
+  <depend>mower_analytics</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -14,6 +14,7 @@
 //
 
 #include <dynamic_reconfigure/client.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Power.h>
 #include <xbot_msgs/SensorDataString.h>
@@ -323,6 +324,7 @@ void powerReconfigCB(const ll::PowerConfig& config) {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "monitoring");
+  mower_analytics::SentryGuard sentry_guard("monitoring");
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("/mower_comms");

--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -14,6 +14,7 @@
 //
 
 #include <dynamic_reconfigure/client.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Power.h>
 #include <xbot_msgs/SensorDataString.h>
@@ -322,6 +323,7 @@ void powerReconfigCB(const ll::PowerConfig& config) {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "monitoring");
+  mower_analytics::SentryGuard sentry_guard("monitoring");
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("/mower_comms");

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -18,6 +18,7 @@
 #include <cryptopp/hex.h>
 #include <cryptopp/sha.h>
 #include <mbf_msgs/RecoveryAction.h>
+#include <mower_analytics/sentry_guard.h>
 #include <nav_msgs/Path.h>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
@@ -603,6 +604,8 @@ bool MowingBehavior::execute_mowing_plan() {
                     "MowingBehavior: (MOW) No recovery behavior configured - "
                     "skipping recovery.");
               } else if (!mbfClientRecovery->waitForServer(ros::Duration(1.0))) {
+                mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Warning,
+                                                           "MBF recovery action server unavailable");
                 ROS_WARN_STREAM(
                     "MowingBehavior: (MOW) Recovery action server unavailable - "
                     "skipping recovery.");
@@ -611,6 +614,8 @@ bool MowingBehavior::execute_mowing_plan() {
                   if (aborted) break;
                   mbf_msgs::RecoveryGoal recoveryGoal;
                   recoveryGoal.behavior = behavior;
+                  mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info,
+                                                             "Running recovery behavior '" + behavior + "'");
                   ROS_INFO_STREAM(
                       "MowingBehavior: (MOW) Path following failed - running recovery "
                       "behavior '"
@@ -618,6 +623,9 @@ bool MowingBehavior::execute_mowing_plan() {
                   auto recoveryState = sendGoalAndWaitUnlessAborted(mbfClientRecovery, recoveryGoal);
                   ROS_INFO_STREAM("MowingBehavior: (MOW) Recovery behavior '" << behavior << "' finished with state "
                                                                               << recoveryState.toString());
+                  mower_analytics::SentryGuard::captureEvent(
+                      mower_analytics::Level::Info,
+                      "Recovery behavior '" + behavior + "' finished with state " + recoveryState.toString());
                   if (recoveryState == actionlib::SimpleClientGoalState::SUCCEEDED) {
                     break;
                   }

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -17,6 +17,7 @@
 
 #include <actionlib/client/simple_action_client.h>
 #include <dynamic_reconfigure/server.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_logic/PowerConfig.h>
 #include <mower_msgs/ESCStatus.h>
 #include <mower_msgs/Emergency.h>
@@ -309,6 +310,9 @@ void setEmergencyMode(bool emergency) {
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
   emergencyStop.request.emergency = emergency;
+  if (emergency) {
+    mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Error, "emergency.triggered");
+  }
 
   ros::Rate retry_delay(1);
   bool success = false;
@@ -646,6 +650,7 @@ int main(int argc, char** argv) {
   buildRootActions();
 
   ros::init(argc, argv, "mower_logic");
+  mower_analytics::SentryGuard sentry_guard("mower_logic");
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("~");
@@ -895,9 +900,28 @@ int main(int argc, char** argv) {
   // Behavior execution loop
   while (ros::ok()) {
     if (currentBehavior != nullptr) {
+      const std::string prev_state = currentBehavior->state_name();
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();
       currentBehavior->exit();
+
+      if (newBehavior) {
+        const std::string next_state = newBehavior->state_name();
+        mower_analytics::SentryGuard::addBreadcrumb("State: " + prev_state + " -> " + next_state);
+        if (next_state != prev_state) {
+          if (next_state == "Mowing") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "mowing.started");
+          } else if (prev_state == "Mowing") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "mowing.completed");
+          }
+          if (next_state == "Docking") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "docking.started");
+          } else if (prev_state == "Docking" && next_state == "Idle") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "docking.completed");
+          }
+        }
+      }
+
       currentBehavior = newBehavior;
     } else {
       high_level_status.state_name = "NULL";

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -352,9 +352,11 @@ void setEmergencyMode(bool emergency) {
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
   emergencyStop.request.emergency = emergency;
-  if (emergency) {
+  static bool last_emergency = false;
+  if (emergency && !last_emergency) {
     mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Error, "emergency.triggered");
   }
+  last_emergency = emergency;
 
   static bool last_emergency = false;
   if (emergency != last_emergency) {

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -17,6 +17,7 @@
 
 #include <actionlib/client/simple_action_client.h>
 #include <dynamic_reconfigure/server.h>
+#include <mower_analytics/sentry_guard.h>
 #include <mower_logic/PowerConfig.h>
 #include <mower_msgs/Bms.h>
 #include <mower_msgs/ESCStatus.h>
@@ -351,6 +352,9 @@ void setEmergencyMode(bool emergency) {
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
   emergencyStop.request.emergency = emergency;
+  if (emergency) {
+    mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Error, "emergency.triggered");
+  }
 
   static bool last_emergency = false;
   if (emergency != last_emergency) {
@@ -718,6 +722,7 @@ int main(int argc, char** argv) {
   buildRootActions();
 
   ros::init(argc, argv, "mower_logic");
+  mower_analytics::SentryGuard sentry_guard("mower_logic");
 
   n = new ros::NodeHandle();
   paramNh = new ros::NodeHandle("~");
@@ -987,11 +992,27 @@ int main(int argc, char** argv) {
   // Behavior execution loop
   while (ros::ok()) {
     if (currentBehavior != nullptr) {
+      const std::string prev_state = currentBehavior->state_name();
       currentBehavior->start(last_config, shared_state);
       Behavior* newBehavior = currentBehavior->execute();
       currentBehavior->exit();
 
       if (newBehavior != nullptr) {
+        const std::string next_state = newBehavior->state_name();
+        mower_analytics::SentryGuard::addBreadcrumb("State: " + prev_state + " -> " + next_state);
+        if (next_state != prev_state) {
+          if (next_state == "Mowing") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "mowing.started");
+          } else if (prev_state == "Mowing") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "mowing.completed");
+          }
+          if (next_state == "Docking") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "docking.started");
+          } else if (prev_state == "Docking" && next_state == "Idle") {
+            mower_analytics::SentryGuard::captureEvent(mower_analytics::Level::Info, "docking.completed");
+          }
+        }
+
         // Session START: undocking begins a new session; mowing is the fallback for idle-start (not on charger)
         if (newBehavior == &UndockingBehavior::INSTANCE || newBehavior == &PerimeterUndockingBehavior::INSTANCE ||
             (newBehavior == &MowingBehavior::INSTANCE && current_session_id.empty())) {
@@ -1012,7 +1033,6 @@ int main(int argc, char** argv) {
       if (newBehavior != currentBehavior && newBehavior != nullptr) {
         publishMowerEvent("STATE", json{{"state", newBehavior->state_name()}});
       }
-
       currentBehavior = newBehavior;
     } else {
       high_level_status.state_name = "NULL";

--- a/src/mower_map/CMakeLists.txt
+++ b/src/mower_map/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(catkin REQUIRED
         xbot_msgs
         xbot_mqtt
         mower_analytics
-        xbot_rpc
         )
 
 ## System dependencies are found with CMake's conventions

--- a/src/mower_map/CMakeLists.txt
+++ b/src/mower_map/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(catkin REQUIRED
         rosbag
         xbot_msgs
         xbot_mqtt
+        mower_analytics
+        xbot_rpc
         )
 
 ## System dependencies are found with CMake's conventions

--- a/src/mower_map/CMakeLists.txt
+++ b/src/mower_map/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(catkin REQUIRED
         grid_map_cv
         rosbag
         xbot_msgs
+        mower_analytics
         xbot_rpc
         )
 

--- a/src/mower_map/package.xml
+++ b/src/mower_map/package.xml
@@ -33,6 +33,7 @@
     <exec_depend>geometry_msgs</exec_depend>
     <depend>xbot_msgs</depend>
     <depend>xbot_rpc</depend>
+    <depend>mower_analytics</depend>
 
 
     <!-- The export tag contains other, unspecified, tags -->

--- a/src/mower_map/package.xml
+++ b/src/mower_map/package.xml
@@ -33,7 +33,6 @@
     <exec_depend>geometry_msgs</exec_depend>
     <depend>xbot_msgs</depend>
     <depend>xbot_mqtt</depend>
-    <depend>xbot_rpc</depend>
     <depend>mower_analytics</depend>
 
 

--- a/src/mower_map/package.xml
+++ b/src/mower_map/package.xml
@@ -33,6 +33,8 @@
     <exec_depend>geometry_msgs</exec_depend>
     <depend>xbot_msgs</depend>
     <depend>xbot_mqtt</depend>
+    <depend>xbot_rpc</depend>
+    <depend>mower_analytics</depend>
 
 
     <!-- The export tag contains other, unspecified, tags -->

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -57,6 +57,9 @@ using json = nlohmann::ordered_json;
 
 // RPC
 #include "xbot_mqtt/provider.h"
+#include <mower_analytics/sentry_guard.h>
+
+#include "xbot_rpc/provider.h"
 
 const std::string MAP_FILE = "map.json";
 const std::string LEGACY_MAP_FILE = "map.bag";
@@ -779,6 +782,7 @@ void convertLegacyMapToJson() {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "mower_map_service");
+  mower_analytics::SentryGuard sentry_guard("mower_map_service");
   ros::NodeHandle n;
   json_map_pub = n.advertise<std_msgs::String>("mower_map_service/json_map", 1, true);
   map_pub = n.advertise<nav_msgs::OccupancyGrid>("mower_map_service/map", 10, true);

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -52,6 +52,8 @@ using json = nlohmann::ordered_json;
 #include "xbot_msgs/MapSize.h"
 
 // RPC
+#include <mower_analytics/sentry_guard.h>
+
 #include "xbot_rpc/provider.h"
 
 const std::string MAP_FILE = "map.json";
@@ -736,6 +738,7 @@ void convertLegacyMapToJson() {
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "mower_map_service");
+  mower_analytics::SentryGuard sentry_guard("mower_map_service");
   ros::NodeHandle n;
   json_map_pub = n.advertise<std_msgs::String>("mower_map_service/json_map", 1, true);
   map_pub = n.advertise<nav_msgs::OccupancyGrid>("mower_map_service/map", 10, true);

--- a/src/mower_map/src/mower_map_service.cpp
+++ b/src/mower_map/src/mower_map_service.cpp
@@ -56,10 +56,9 @@ using json = nlohmann::ordered_json;
 #include "xbot_msgs/MapSize.h"
 
 // RPC
-#include "xbot_mqtt/provider.h"
 #include <mower_analytics/sentry_guard.h>
 
-#include "xbot_rpc/provider.h"
+#include "xbot_mqtt/provider.h"
 
 const std::string MAP_FILE = "map.json";
 const std::string LEGACY_MAP_FILE = "map.bag";


### PR DESCRIPTION
Introduces anonymous telemetry to help the project ship stable releases faster and surface bugs that only appear in the field.

What's tracked (no GPS or location data ever collected):
- Crashes and C++ exceptions with stack traces (all ROS nodes)
- Mow start/stop, docking, emergency events (from mower_logic)
- Software version and hardware platform per session

Implementation:
- New mower_analytics package builds libmower_analytics_sentry.so, a thin RAII wrapper (SentryGuard) around sentry-native with the crashpad out-of-process backend for reliable crash capture
- SentryGuard linked into mower_logic, monitoring, mower_comms_v1/v2, mower_map_service, and mower_simulation — one line in each main()
- SentryGuard::captureEvent() / addBreadcrumb() callable from anywhere without exposing sentry.h to consumers
- Prints a clear opt-in prompt on startup when OM_TELEMETRY_ENABLE is unset; silent no-op when set to false
- Default DSN pre-configured in the Docker entrypoint; users only need to set OM_TELEMETRY_ENABLE=true in mower_config.sh to participate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional anonymous telemetry and crash reporting (toggle via OM_TELEMETRY_ENABLE).
  * Anonymous events collected: mow start/stop, docking, emergencies, software version, hardware platform; no GPS/location data.
  * Default reporting endpoint can be overridden via OM_SENTRY_DSN.
  * Telemetry integrated into multiple runtime components; processes warn at startup until preference is set.

* **Documentation**
  * Added examples and notes for enabling/disabling telemetry and configuring the reporting endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/289)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->