### PR TITLE
Log GPS warnings only if we care about GPS

### DIFF
--- a/src/lib/xbot_positioning/src/xbot_positioning.cpp
+++ b/src/lib/xbot_positioning/src/xbot_positioning.cpp
@@ -70,7 +70,6 @@ xbot_msgs::AbsolutePose xb_absolute_pose_msg;
 bool gps_enabled = true;
 int gps_outlier_count = 0;
 int valid_gps_samples = 0;
-int gps_message_throttle = 1;
 
 ros::Time last_gps_time(0.0);
 
@@ -224,10 +223,9 @@ bool setPose(xbot_positioning::SetPoseSrvRequest &req, xbot_positioning::SetPose
 }
 
 void onPose(const xbot_msgs::AbsolutePose::ConstPtr &msg) {
-    if (!gps_enabled) {
-        ROS_INFO_STREAM_THROTTLE(gps_message_throttle, "dropping GPS update, since gps_enabled = false.");
-        return;
-    }
+  if (!gps_enabled) {
+    return;
+  }
     // TODO fuse with high covariance?
     if ((msg->flags & (xbot_msgs::AbsolutePose::FLAG_GPS_RTK_FIXED)) == 0) {
         ROS_INFO_STREAM_THROTTLE(1, "Dropped GPS update, since it's not RTK Fixed");
@@ -337,7 +335,6 @@ int main(int argc, char **argv) {
     paramNh.param("debug", publish_debug, false);
     paramNh.param("antenna_offset_x", antenna_offset_x, 0.0);
     paramNh.param("antenna_offset_y", antenna_offset_y, 0.0);
-    paramNh.param("gps_message_throttle", gps_message_throttle, 1);
 
     core.setAntennaOffset(antenna_offset_x, antenna_offset_y);
 

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -450,7 +450,9 @@ void checkSafety(const ros::TimerEvent& timer_event) {
     setLastGoodGPS(ros::Time::now());
     high_level_status.gps_quality_percent =
         1.0 - fmin(1.0, last_pose.position_accuracy / last_config.max_position_accuracy);
-    ROS_INFO_STREAM_THROTTLE(10, "GPS quality: " << high_level_status.gps_quality_percent);
+    if (currentBehavior->needs_gps()) {
+      ROS_INFO_STREAM_THROTTLE(10, "GPS quality: " << high_level_status.gps_quality_percent);
+    }
   } else {
     // GPS = bad, set quality to 0
     high_level_status.gps_quality_percent = 0;
@@ -458,7 +460,9 @@ void checkSafety(const ros::TimerEvent& timer_event) {
       // set this if we don't even have an orientation
       high_level_status.gps_quality_percent = -1;
     }
-    ROS_WARN_STREAM_THROTTLE(1, "Low quality GPS");
+    if (currentBehavior->needs_gps()) {
+      ROS_WARN_STREAM_THROTTLE(1, "Low quality GPS");
+    }
   }
 
   bool gpsTimeout = ros::Time::now() - last_good_gps > ros::Duration(last_config.gps_timeout);
@@ -466,7 +470,9 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   if (gpsTimeout) {
     // GPS = bad, set quality to 0
     high_level_status.gps_quality_percent = 0;
-    ROS_WARN_STREAM_THROTTLE(1, "GPS timeout");
+    if (currentBehavior->needs_gps()) {
+      ROS_WARN_STREAM_THROTTLE(1, "GPS timeout");
+    }
   }
 
   if (currentBehavior != nullptr && currentBehavior->needs_gps()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPS warnings now only appear when the mower's current behavior requires GPS, reducing irrelevant alerts.
  * GPS-related warning frequency adjusted for more timely notifications.
  * Removed redundant "dropping GPS update" log when GPS is disabled to reduce noise.
  * Preserved existing GPS quality reporting behavior to keep status values consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/290)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->