### PR TITLE
Add parameter Dangerously Override Hardware Current Limit

### DIFF
--- a/src/mower_comms_v2/src/PowerServiceInterface.cpp
+++ b/src/mower_comms_v2/src/PowerServiceInterface.cpp
@@ -81,6 +81,7 @@ bool PowerServiceInterface::OnConfigurationRequested(uint16_t service_id) {
   SetRegisterCriticalBatteryHighVoltage(battery_critical_high_voltage_);
   SetRegisterChargeCurrent(battery_charge_current_);
   SetRegisterSystemCurrent(system_current_);
+  SetRegisterDangerouslyOverrideHardwareCurrentLimit(dangerously_override_hardware_current_limit_ ? 1 : 0);
   CommitTransaction();
   return true;
 }

--- a/src/mower_comms_v2/src/PowerServiceInterface.h
+++ b/src/mower_comms_v2/src/PowerServiceInterface.h
@@ -16,7 +16,8 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
   PowerServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx,
                         const ros::Publisher& status_publisher, float battery_full_voltage, float battery_empty_voltage,
                         float battery_critical_voltage, float battery_critical_high_voltage,
-                        float battery_charge_current, float system_current)
+                        float battery_charge_current, float system_current,
+                        bool dangerously_override_hardware_current_limit)
       : PowerServiceInterfaceBase(service_id, ctx),
         status_publisher_(status_publisher),
         battery_full_voltage_(battery_full_voltage),
@@ -24,7 +25,8 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
         battery_critical_voltage_(battery_critical_voltage),
         battery_critical_high_voltage_(battery_critical_high_voltage),
         battery_charge_current_(battery_charge_current),
-        system_current_(system_current) {
+        system_current_(system_current),
+        dangerously_override_hardware_current_limit_(dangerously_override_hardware_current_limit) {
   }
 
  protected:
@@ -61,6 +63,7 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
   float battery_critical_high_voltage_;
   float battery_charge_current_;
   float system_current_;
+  bool dangerously_override_hardware_current_limit_;
 };
 
 struct BatteryStatusBitName {

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -233,9 +233,12 @@ int main(int argc, char** argv) {
   }
   paramNh.getParam("services/power/charge_current", charge_current);
   paramNh.getParam("services/power/system_current", system_current);
+  bool dangerously_override_hardware_current_limit = false;
+  paramNh.getParam("services/power/dangerously_override_hardware_current_limit",
+                   dangerously_override_hardware_current_limit);
   power_service = std::make_unique<PowerServiceInterface>(
       xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
-      battery_critical_high_voltage, charge_current, system_current);
+      battery_critical_high_voltage, charge_current, system_current, dangerously_override_hardware_current_limit);
   power_service->Start();
 
   // GPS service


### PR DESCRIPTION
This parameter should make it possible voor V2 hardware users to set the Charge Current to a value that might endanger hardware. By default, the Charge Current is max 1A.

Adding
` /ll/services/power/dangerously_override_hardware_current_limit: true
`in mower_params.yaml overrides this maximum.

This parameter requires changes in 3 repositories. The pull requests all have the same name.

### https://github.com/xtech/definitions-open-mower

Definitions-open-mower is used by fw-openmower-v2 and by
open_mower_ros. At testing time, they used an older version, commit
services @ dad32a9

This pull request adds the definition of
  "Dangerously Override Hardware Current Limit"

### https://github.com/xtech/fw-openmower-v2

This pull request adds reading the optional value of
 "Dangerously Override Hardware Current Limit" from ROS.
If set, it will allow higher Charge Currents then 1A

### https://github.com/ClemensElflein/open_mower_ros

This pull request adds reading dangerously_override_hardware_current_limit
from open_mower.yaml and making it available to ROS.

### These pull requests have been tested against:

- definitions-open-mower @ dad32a9
- fw-openmower-v2 @ 3b39af2
- open_mower_ros @ da7a52a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable hardware current-limit override for power management, controllable at runtime.
  * Added a dead-reckoning fallback so mowing can continue when GPS is lost (docking still needs GPS).
* **Configuration**
  * New boolean option to enable dead-reckoning (default: false) exposed in defaults and launch params.
  * Example config file updated with a commented setting for dead-reckoning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->