### PR TITLE
Make Backward/Forward Recovery behavior look ahead for obstacles, and enable it by default.

### DIFF
--- a/src/lib/ftc_local_planner/include/ftc_local_planner/backward_forward_recovery.h
+++ b/src/lib/ftc_local_planner/include/ftc_local_planner/backward_forward_recovery.h
@@ -6,6 +6,7 @@
 #include <tf2_ros/buffer.h>
 #include <base_local_planner/costmap_model.h>
 #include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Pose.h>
 #include <string>
 
 namespace ftc_local_planner
@@ -22,7 +23,7 @@ public:
 
 private:
   bool attemptMove(double distance, bool forward);
-  bool isPositionValid(double x, double y);
+  bool isPathClear(const geometry_msgs::Pose& pose, bool forward);
 
   std::string name_;
   bool initialized_;     
@@ -33,6 +34,7 @@ private:
   double linear_vel_;
   double check_frequency_;
   unsigned char max_cost_threshold_;
+  double obstacle_check_distance_;
   ros::Duration timeout_;
 };
 

--- a/src/lib/ftc_local_planner/src/backward_forward_recovery.cpp
+++ b/src/lib/ftc_local_planner/src/backward_forward_recovery.cpp
@@ -119,28 +119,31 @@ bool BackwardForwardRecovery::attemptMove(double distance, bool forward)
 
 bool BackwardForwardRecovery::isPathClear(const geometry_msgs::Pose& pose, bool forward)
 {
+  costmap_2d::Costmap2D* costmap = local_costmap_->getCostmap();
+  boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(costmap->getMutex()));
+  
   double yaw = tf2::getYaw(pose.orientation);
   if (!forward)
   {
     yaw += M_PI;
   }
 
-  double resolution = local_costmap_->getCostmap()->getResolution();
+  double resolution = costmap->getResolution();
   unsigned int steps = std::ceil(obstacle_check_distance_ / resolution);
 
-  for (unsigned int i = 1; i <= steps; ++i)
+  for (unsigned int i = 0; i <= steps; ++i)
   {
     double dist = i * resolution;
     double x = pose.position.x + dist * std::cos(yaw);
     double y = pose.position.y + dist * std::sin(yaw);
 
     unsigned int mx, my;
-    if (!local_costmap_->getCostmap()->worldToMap(x, y, mx, my))
+    if (!costmap->worldToMap(x, y, mx, my))
     {
       return false;
     }
 
-    unsigned char cost = local_costmap_->getCostmap()->getCost(mx, my);
+    unsigned char cost = costmap->getCost(mx, my);
     if (cost > max_cost_threshold_)
     {
       return false;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -575,10 +575,7 @@ bool MowingBehavior::execute_mowing_plan() {
           currentMowingPathIndex = 0;
           // continue with next segment
         } else {
-          // we didnt drive all points in the mow path, so we go into pause mode
-          // TODO: we should figure out the likely reason for our failure to complete the path
-          // if GPS -> PAUSE
-          // if something else -> Recovery Behaviour ?
+          // we didnt drive all points in the mow path, so we wait for GPS or execute the recovery behaviors.
 
           // currentMowingPathIndex might be 0 if we never consumed one of the points, we advance at least 1 point
           if (currentMowingPathIndex == 0) currentMowingPathIndex++;
@@ -588,7 +585,7 @@ bool MowingBehavior::execute_mowing_plan() {
             // here. Mirror MBF's move_base behavior: run each configured recovery behavior in
             // order until one succeeds (or we are aborted / they all fail). No-op if MBF has
             // no recovery configured.
-            if (!aborted) {
+            if (hasGoodGPS() && !aborted) {
               mowerEnabled = false;
               std::vector<std::string> recoveryBehaviors = getConfiguredRecoveryBehaviors();
               if (recoveryBehaviors.empty()) {

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -18,6 +18,7 @@
 #include <cryptopp/hex.h>
 #include <cryptopp/sha.h>
 #include <nav_msgs/Path.h>
+#include <mbf_msgs/RecoveryAction.h>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 
@@ -36,6 +37,7 @@ extern ros::ServiceClient clearNavPointClient;
 
 extern actionlib::SimpleActionClient<mbf_msgs::MoveBaseAction>* mbfClient;
 extern actionlib::SimpleActionClient<mbf_msgs::ExePathAction>* mbfClientExePath;
+extern actionlib::SimpleActionClient<mbf_msgs::RecoveryAction>* mbfClientRecovery;
 extern mower_logic::MowerLogicConfig getConfig();
 extern void setConfig(mower_logic::MowerLogicConfig);
 
@@ -276,6 +278,30 @@ void printNavState(int state) {
     default: ROS_INFO(">>> State: Unknown Hu ? <<<"); break;
   }
 }
+
+namespace {
+// Returns the names of the recovery behaviors configured on move_base_flex
+// (its "recovery_behaviors" param), in order, or an empty list if none are
+// configured. This avoids hardcoding behavior names and makes recovery a no-op
+// when MBF has no recovery configured.
+std::vector<std::string> getConfiguredRecoveryBehaviors() {
+  std::vector<std::string> names;
+  XmlRpc::XmlRpcValue behaviors;
+  if (!ros::param::get("/move_base_flex/recovery_behaviors", behaviors)) {
+    return names;
+  }
+  if (behaviors.getType() != XmlRpc::XmlRpcValue::TypeArray) {
+    return names;
+  }
+  for (int i = 0; i < behaviors.size(); i++) {
+    XmlRpc::XmlRpcValue &b = behaviors[i];
+    if (b.getType() == XmlRpc::XmlRpcValue::TypeStruct && b.hasMember("name")) {
+      names.push_back(static_cast<std::string>(b["name"]));
+    }
+  }
+  return names;
+}
+}  // namespace
 
 bool MowingBehavior::execute_mowing_plan() {
   int first_point_attempt_counter = 0;
@@ -557,6 +583,37 @@ bool MowingBehavior::execute_mowing_plan() {
           // currentMowingPathIndex might be 0 if we never consumed one of the points, we advance at least 1 point
           if (currentMowingPathIndex == 0) currentMowingPathIndex++;
           if (!requested_pause_flag) {
+            // Path following failed (not a user-requested pause/abort). ExePath, unlike the
+            // MoveBase action, never invokes MBF recovery on its own, so trigger it explicitly
+            // here. Mirror MBF's move_base behavior: run each configured recovery behavior in
+            // order until one succeeds (or we are aborted / they all fail). No-op if MBF has
+            // no recovery configured.
+            if (!aborted) {
+              mowerEnabled = false;
+              std::vector<std::string> recoveryBehaviors = getConfiguredRecoveryBehaviors();
+              if (recoveryBehaviors.empty()) {
+                ROS_INFO_STREAM("MowingBehavior: (MOW) No recovery behavior configured - "
+                                "skipping recovery.");
+              } else if (!mbfClientRecovery->waitForServer(ros::Duration(1.0))) {
+                ROS_WARN_STREAM("MowingBehavior: (MOW) Recovery action server unavailable - "
+                                "skipping recovery.");
+              } else {
+                for (const auto &behavior : recoveryBehaviors) {
+                  if (aborted) break;
+                  mbf_msgs::RecoveryGoal recoveryGoal;
+                  recoveryGoal.behavior = behavior;
+                  ROS_INFO_STREAM("MowingBehavior: (MOW) Path following failed - running recovery "
+                                  "behavior '"
+                                  << behavior << "'.");
+                  auto recoveryState = sendGoalAndWaitUnlessAborted(mbfClientRecovery, recoveryGoal);
+                  ROS_INFO_STREAM("MowingBehavior: (MOW) Recovery behavior '"
+                                  << behavior << "' finished with state " << recoveryState.toString());
+                  if (recoveryState == actionlib::SimpleClientGoalState::SUCCEEDED) {
+                    break;
+                  }
+                }
+              }
+            }
             ROS_INFO_STREAM("MowingBehavior: (MOW) PAUSED due to MBF Error at " << currentMowingPathIndex);
             paused = true;
             update_actions();

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -17,8 +17,8 @@
 #include <cryptopp/cryptlib.h>
 #include <cryptopp/hex.h>
 #include <cryptopp/sha.h>
-#include <nav_msgs/Path.h>
 #include <mbf_msgs/RecoveryAction.h>
+#include <nav_msgs/Path.h>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 
@@ -294,7 +294,7 @@ std::vector<std::string> getConfiguredRecoveryBehaviors() {
     return names;
   }
   for (int i = 0; i < behaviors.size(); i++) {
-    XmlRpc::XmlRpcValue &b = behaviors[i];
+    XmlRpc::XmlRpcValue& b = behaviors[i];
     if (b.getType() == XmlRpc::XmlRpcValue::TypeStruct && b.hasMember("name")) {
       names.push_back(static_cast<std::string>(b["name"]));
     }
@@ -589,22 +589,25 @@ bool MowingBehavior::execute_mowing_plan() {
               mowerEnabled = false;
               std::vector<std::string> recoveryBehaviors = getConfiguredRecoveryBehaviors();
               if (recoveryBehaviors.empty()) {
-                ROS_INFO_STREAM("MowingBehavior: (MOW) No recovery behavior configured - "
-                                "skipping recovery.");
+                ROS_INFO_STREAM(
+                    "MowingBehavior: (MOW) No recovery behavior configured - "
+                    "skipping recovery.");
               } else if (!mbfClientRecovery->waitForServer(ros::Duration(1.0))) {
-                ROS_WARN_STREAM("MowingBehavior: (MOW) Recovery action server unavailable - "
-                                "skipping recovery.");
+                ROS_WARN_STREAM(
+                    "MowingBehavior: (MOW) Recovery action server unavailable - "
+                    "skipping recovery.");
               } else {
-                for (const auto &behavior : recoveryBehaviors) {
+                for (const auto& behavior : recoveryBehaviors) {
                   if (aborted) break;
                   mbf_msgs::RecoveryGoal recoveryGoal;
                   recoveryGoal.behavior = behavior;
-                  ROS_INFO_STREAM("MowingBehavior: (MOW) Path following failed - running recovery "
-                                  "behavior '"
-                                  << behavior << "'.");
+                  ROS_INFO_STREAM(
+                      "MowingBehavior: (MOW) Path following failed - running recovery "
+                      "behavior '"
+                      << behavior << "'.");
                   auto recoveryState = sendGoalAndWaitUnlessAborted(mbfClientRecovery, recoveryGoal);
-                  ROS_INFO_STREAM("MowingBehavior: (MOW) Recovery behavior '"
-                                  << behavior << "' finished with state " << recoveryState.toString());
+                  ROS_INFO_STREAM("MowingBehavior: (MOW) Recovery behavior '" << behavior << "' finished with state "
+                                                                              << recoveryState.toString());
                   if (recoveryState == actionlib::SimpleClientGoalState::SUCCEEDED) {
                     break;
                   }

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -36,6 +36,7 @@
 #include "ftc_local_planner/PlannerGetProgress.h"
 #include "mbf_msgs/ExePathAction.h"
 #include "mbf_msgs/MoveBaseAction.h"
+#include "mbf_msgs/RecoveryAction.h"
 #include "mower_logic/MowerLogicConfig.h"
 #include "mower_logic/utils.h"
 #include "mower_map/ClearMapSrv.h"
@@ -65,6 +66,7 @@ ros::NodeHandle* paramNh;
 dynamic_reconfigure::Server<mower_logic::MowerLogicConfig>* reconfigServer;
 actionlib::SimpleActionClient<mbf_msgs::MoveBaseAction>* mbfClient;
 actionlib::SimpleActionClient<mbf_msgs::ExePathAction>* mbfClientExePath;
+actionlib::SimpleActionClient<mbf_msgs::RecoveryAction>* mbfClientRecovery;
 
 ros::Publisher cmd_vel_pub, high_level_state_publisher;
 mower_logic::MowerLogicConfig last_config;
@@ -698,6 +700,7 @@ int main(int argc, char** argv) {
 
   mbfClient = new actionlib::SimpleActionClient<mbf_msgs::MoveBaseAction>("/move_base_flex/move_base");
   mbfClientExePath = new actionlib::SimpleActionClient<mbf_msgs::ExePathAction>("/move_base_flex/exe_path");
+  mbfClientRecovery = new actionlib::SimpleActionClient<mbf_msgs::RecoveryAction>("/move_base_flex/recovery");
 
   emergency_state_subscriber.Start(n);
   status_state_subscriber.Start(n);

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -726,6 +726,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -736,6 +737,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -747,6 +749,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -758,6 +761,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -768,6 +772,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -778,6 +783,7 @@ int main(int argc, char** argv) {
       delete (reconfigServer);
       delete (mbfClient);
       delete (mbfClientExePath);
+      delete (mbfClientRecovery);
       return 1;
     }
     r.sleep();
@@ -789,6 +795,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
 
     return 1;
   }
@@ -799,6 +806,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
 
     return 1;
   }
@@ -808,6 +816,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
 
     return 1;
   }
@@ -818,6 +827,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
 
     return 1;
   }
@@ -827,6 +837,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
 
     return 1;
   }
@@ -837,6 +848,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 2;
   }
   ROS_INFO("Waiting for docking point server");
@@ -845,6 +857,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 2;
   }
   ROS_INFO("Waiting for nav point server");
@@ -853,6 +866,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 2;
   }
   ROS_INFO("Waiting for clear nav point server");
@@ -861,6 +875,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 2;
   }
 
@@ -870,6 +885,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 3;
   }
 
@@ -879,6 +895,7 @@ int main(int argc, char** argv) {
     delete (reconfigServer);
     delete (mbfClient);
     delete (mbfClientExePath);
+    delete (mbfClientRecovery);
     return 3;
   }
 
@@ -933,5 +950,6 @@ int main(int argc, char** argv) {
   delete (reconfigServer);
   delete (mbfClient);
   delete (mbfClientExePath);
+  delete (mbfClientRecovery);
   return 0;
 }

--- a/src/open_mower/params/move_base_flex.yaml
+++ b/src/open_mower/params/move_base_flex.yaml
@@ -8,12 +8,18 @@ controllers:
   - name: DockingFTCPlanner
     type: ftc_local_planner/FTCPlanner
 
+recovery_behaviors:
+  - name: BackwardForwardRecovery
+    type: ftc_local_planner/BackwardForwardRecovery
 
 controller_frequency: 1.0
 controller_patience: 30.0
 
 planner_frequency: 1.0
 planner_patience: 5.0
+
+recovery_enabled: true
+recovery_patience: 7.0
 
 oscillation_timeout: 10.0
 oscillation_distance: 0.2

--- a/src/open_mower/params/openmower_defaults_v2.yaml
+++ b/src/open_mower/params/openmower_defaults_v2.yaml
@@ -51,3 +51,9 @@ mower_logic:
 
 xbot_monitoring:
   external_mqtt_enable: false
+
+
+# Openmower doesn't work in m/s but duty cycle by default, so we must adjust the speed for the recovery behavior
+move_base_flex:
+  BackwardForwardRecovery:
+    linear_vel: 0.6


### PR DESCRIPTION
1. Enable the recovery behavior by default.
2. Make the recovery behavior check not just the costmap at the current location, but in a line ahead where it's moving to.
3. Manually invoke the recovery behavior in the case where MBF will not recover by itself (specifically when in path following mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery moves now sample and validate points along the full forward/backward path using a configurable obstacle-check distance.
  * Mowing can invoke configured MBF-style recovery behaviors sequentially and stop on the first successful recovery.

* **Bug Fixes**
  * Moves now stop and report failure if an obstacle is detected too close along the recovery path.

* **Chores**
  * Default runtime config enables recovery and adds a backward/forward recovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->