### PR TITLE
Prepared #293

### DIFF
--- a/src/mower_comms_v2/src/PowerServiceInterface.cpp
+++ b/src/mower_comms_v2/src/PowerServiceInterface.cpp
@@ -65,7 +65,7 @@ bool PowerServiceInterface::OnConfigurationRequested(uint16_t service_id) {
     SetRegisterReChargeVoltage(static_cast<ReChargeVoltages>(charge_recharge_voltage_));
   }
   if (system_current_ > 0.0f) SetRegisterSystemCurrent(system_current_);
-  SetRegisterDangerouslyOverrideHardwareChargeCurrentLimit(dangerously_override_hardware_charge_current_limit_ ? 1 : 0);
+  SetRegisterDangerouslyOverrideHardwareChargeCurrentLimit(override_hardware_charge_current_limit_ ? 1 : 0);
   CommitTransaction();
   return true;
 }

--- a/src/mower_comms_v2/src/PowerServiceInterface.cpp
+++ b/src/mower_comms_v2/src/PowerServiceInterface.cpp
@@ -65,6 +65,7 @@ bool PowerServiceInterface::OnConfigurationRequested(uint16_t service_id) {
     SetRegisterReChargeVoltage(static_cast<ReChargeVoltages>(charge_recharge_voltage_));
   }
   if (system_current_ > 0.0f) SetRegisterSystemCurrent(system_current_);
+  SetRegisterDangerouslyOverrideHardwareChargeCurrentLimit(dangerously_override_hardware_charge_current_limit_ ? 1 : 0);
   CommitTransaction();
   return true;
 }

--- a/src/mower_comms_v2/src/PowerServiceInterface.h
+++ b/src/mower_comms_v2/src/PowerServiceInterface.h
@@ -24,7 +24,7 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
                         const ros::Publisher& status_publisher, float battery_full_voltage, float battery_empty_voltage,
                         float battery_critical_voltage, float battery_critical_high_voltage, float charge_voltage,
                         float charge_current, float charge_termination_current, float charge_precharge_current,
-                        int charge_recharge_voltage, float system_current)
+                        int charge_recharge_voltage, float system_current, bool override_hardware_charge_current_limit)
       : PowerServiceInterfaceBase(service_id, ctx),
         status_publisher_(status_publisher),
         battery_full_voltage_(battery_full_voltage),
@@ -36,7 +36,8 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
         charge_termination_current_(charge_termination_current),
         charge_precharge_current_(charge_precharge_current),
         charge_recharge_voltage_(charge_recharge_voltage),
-        system_current_(system_current) {
+        system_current_(system_current),
+        override_hardware_charge_current_limit_(override_hardware_charge_current_limit) {
   }
 
  protected:
@@ -69,6 +70,7 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
   float charge_precharge_current_;
   int charge_recharge_voltage_;
   float system_current_;
+  bool override_hardware_charge_current_limit_;
 };
 
 #endif  // POWERSERVICEINTERFACE_H

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -250,11 +250,13 @@ int main(int argc, char** argv) {
   // Optional settings also required for charger DPM (dynamic power management)
   float system_current = -1.0f;  // Max. current allowed to be drawn from wall AC/DC
   paramNh.getParam("services/power/system_current", system_current);
-
+  bool override_hw_charge_current_limit = false;
+  paramNh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
+                   override_hw_charge_current_limit);
   power_service = std::make_unique<PowerServiceInterface>(
       xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
       battery_critical_high_voltage, charge_voltage, charge_current, charge_termination_current,
-      charge_precharge_current, charge_recharge_voltage, system_current);
+      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit);
   power_service->Start();
 
   // BMS service


### PR DESCRIPTION
Prepared PR #293 

- Add "Charge" to register name as @rovo89 suggested
- Changed register from "optional" to "default" to be semantically more correct  as @rovo89 suggested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable hardware charge-current override capability for power management operations.

* **Chores**
  * Updated service dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->