### PR TITLE
Add rosserial to Docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,19 @@ RUN rosdep update --rosdistro $ROS_DISTRO
 
 ####################################################################################################
 
+# Build rosserial once and re-use the prebuilt install
+FROM base AS rosserial
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Clone from a fixed commit hash
+RUN mkdir -p /opt/rosserial/src && cd /opt/rosserial/src && git clone --no-checkout https://github.com/tongtybj/rosserial && cd rosserial && git fetch --depth=1 origin 47a73176d281eb7cc582e6dc1eb83ada40cb5f8d && git checkout FETCH_HEAD
+
+WORKDIR /opt/rosserial/
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make_isolated --install --install-space /opt/prebuilt/rosserial --only-pkg-with-deps rosserial_server"
+
+####################################################################################################
+
 # Build slic3r_coverage_planner once and re-use the prebuilt install
 FROM base AS slic3r
 
@@ -52,7 +65,8 @@ FROM base AS assemble
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Fetch the slic3r built earlier
+# Fetch the rosserial and slic3r built earlier
+COPY --link --from=rosserial /opt/prebuilt/rosserial /opt/prebuilt/rosserial
 COPY --link --from=slic3r /opt/prebuilt/slic3r_coverage_planner /opt/prebuilt/slic3r_coverage_planner
 
 # Fetch the list of packages
@@ -68,7 +82,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo \"v0.0.0\")" > version_info.env
 

--- a/docker/Dockerfile.Legacy
+++ b/docker/Dockerfile.Legacy
@@ -21,6 +21,19 @@ RUN rosdep update --rosdistro $ROS_DISTRO
 
 ####################################################################################################
 
+# Build rosserial once and re-use the prebuilt install
+FROM base AS rosserial
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Clone from a fixed commit hash
+RUN mkdir -p /opt/rosserial/src && cd /opt/rosserial/src && git clone --no-checkout https://github.com/tongtybj/rosserial && cd rosserial && git fetch --depth=1 origin 47a73176d281eb7cc582e6dc1eb83ada40cb5f8d && git checkout FETCH_HEAD
+
+WORKDIR /opt/rosserial/
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && catkin_make_isolated --install --install-space /opt/prebuilt/rosserial --only-pkg-with-deps rosserial_server"
+
+####################################################################################################
+
 # Get slic3r_coverage_planner and build that. We will pull the finished install folder from this.
 # This stage should cache most of the time, that's why it's not derived from the fetch stage, but copies stuff instead.
 FROM base AS slic3r
@@ -64,7 +77,8 @@ FROM base AS assemble
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-#Fetch the slic3r built earlier, this only changes if slic3r was changed (probably never)
+# Fetch the rosserial and slic3r built earlier
+COPY --link --from=rosserial /opt/prebuilt/rosserial /opt/prebuilt/rosserial
 COPY --link --from=slic3r /opt/prebuilt/slic3r_coverage_planner /opt/prebuilt/slic3r_coverage_planner
 
 #Fetch the list of packages, this only changes if new dependencies have been added (only sometimes)
@@ -80,7 +94,7 @@ RUN rm -rf /opt/open_mower_ros/src/lib/slic3r_coverage_planner /apt-install_list
 
 WORKDIR /opt/open_mower_ros
 
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
+RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
 RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo "v0.0.0")" > version_info.env
 


### PR DESCRIPTION
This is a (relatively small) dependency of Mowgli (about 5mb).  By adding this to the docker image, we can use the same image for Mowgli and for regular OpenMower.

Note:

- Rosserial requires access to up to date message/service information.  Splitting it off into its own separate container means we still have a dependency on the main open_mower_ros build, and there is the potential for incompatibilities.
- I set it up to build rosserial first, using the same technique as the slic3r build, so it remains cached and does not need to be rebuilt.  It will still have access to the needed message definitions at runtime.
- The version of the rosserial code used by mowgli has never changed, and I pinned it to an exact hash so it won't ever change in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved Docker build process with optimized dependency compilation and artifact caching for faster, more consistent image builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ClemensElflein/open_mower_ros/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->