### PR TITLE
Fix NTRIP reconnect: swap max attempts and wait seconds

### DIFF
--- a/src/open_mower/params/openmower_defaults_v2.yaml
+++ b/src/open_mower/params/openmower_defaults_v2.yaml
@@ -22,8 +22,8 @@ xbot_positioning:
   debug: false
 
 ntrip_client:
-  reconnect_attempt_max: 5
-  reconnect_attempt_wait_seconds: 99999
+  reconnect_attempt_max: 99999
+  reconnect_attempt_wait_seconds: 5
 
 mower_logic:
   automatic_mode: 0


### PR DESCRIPTION
`reconnect_attempt_max` and `reconnect_attempt_wait_seconds` were swapped — 5 attempts with 99999s wait between them. Now retries indefinitely with 5s between attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NTRIP client reconnection configuration parameters to improve connection reliability with more frequent reconnection attempts and shorter wait intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->