### PR TITLE
Add yf_cover_ui supoort for V2 hardware

### DIFF
--- a/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
+++ b/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
@@ -66,9 +66,8 @@ yf_cover_ui:
     channel: button
     button_id: 2
     actions:
-      idle/short: "mower_logic/command_home"
-      mowing/short: "mower_logic/command_home"
-      paused/short: "mower_logic/command_home"
+      mowing/short: "mower_logic:mowing/abort_mowing"
+      paused/short: "mower_logic:mowing/abort_mowing"
 
   - name: CoverUI play/start button
     channel: button

--- a/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
+++ b/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
@@ -26,3 +26,86 @@ gpio:
     emergency:
       reason: stop
       delay: 10
+
+yf_cover_ui:
+  # ---- Emergency channels ----
+  # These directly reflect the Emergency_state bitmask received from the CoverUI panel.
+  # stop1 / stop2 are the STOP buttons on the CoverUI panel.
+  # lift / liftx are the lift sensors reported by the CoverUI panel.
+  # Note: the GPIO inputs above may detect the same physical events via different hardware paths.
+
+  - name: CoverUI stop button 1
+    channel: stop1
+    emergency:
+      reason: stop
+      delay: 10
+
+  - name: CoverUI stop button 2
+    channel: stop2
+    emergency:
+      reason: stop
+      delay: 10
+
+  - name: CoverUI lift sensor 1
+    channel: lift
+    emergency:
+      reason: lift
+      delay: 100
+
+  - name: CoverUI lift sensor 2
+    channel: liftx
+    emergency:
+      reason: lift
+      delay: 100
+
+  # ---- Button channels ----
+  # button_id values match those sent by the YardForce 500 CoverUI panel firmware.
+  # See old firmware mower_comms.cpp handleLowLevelUIEvent() for reference.
+
+  - name: CoverUI Home/docking button
+    channel: button
+    button_id: 2
+    actions:
+      idle/short: "mower_logic/command_home"
+      mowing/short: "mower_logic/command_home"
+      paused/short: "mower_logic/command_home"
+
+  - name: CoverUI play/start button
+    channel: button
+    button_id: 3
+    actions:
+      idle/short: "mower_logic:idle/start_mowing"
+      mowing/short: "mower_logic:mowing/pause"
+      paused/short: "mower_logic:mowing/continue"
+      idle/long: "mower_logic/reset_emergency"
+      mowing/long: "mower_logic/reset_emergency"
+      paused/long: "mower_logic/reset_emergency"
+      docking/long: "mower_logic/reset_emergency"
+      undocking/long: "mower_logic/reset_emergency"
+      area_recording/long: "mower_logic/reset_emergency"
+
+  - name: CoverUI S1 button
+    channel: button
+    button_id: 4
+    actions:
+      idle/short: "mower_logic:idle/start_mowing"
+      mowing/short: "mower_logic:mowing/pause"
+      paused/short: "mower_logic:mowing/continue"
+
+  - name: CoverUI S2/home button
+    channel: button
+    button_id: 5
+    actions:
+      mowing/short: "mower_logic:mowing/abort_mowing"
+      paused/short: "mower_logic:mowing/abort_mowing"
+
+  - name: CoverUI lock/reset button (long press)
+    channel: button
+    button_id: 6
+    actions:
+      idle/long: "mower_logic/reset_emergency"
+      mowing/long: "mower_logic/reset_emergency"
+      paused/long: "mower_logic/reset_emergency"
+      docking/long: "mower_logic/reset_emergency"
+      undocking/long: "mower_logic/reset_emergency"
+      area_recording/long: "mower_logic/reset_emergency"


### PR DESCRIPTION
Add yf_cover_ui supoort for V2 hardware

This PR exists of two parts:
- add yf_cover_ui support to fw-openmower-v2
- add YF Cover UI inputs for YardForce 500 platform in open_mower_ros

Implemented:

Emergency channels:
- stop1/stop2: STOP buttons on the panel, mapped to stop emergency
- lift/liftx:  Lift sensors reported by the panel, mapped to lift emergency

Buttons (button_id values from old firmware handleLowLevelUIEvent):
- button_id 2 (Home): start docking
- button_id 3 (Play): start/pause mowing + reset emergency on long press
- button_id 4 (S1):   start/pause mowing
- button_id 5 (S2):   abort mowing / return home
- button_id 6 (Lock): reset emergency on long press

Leds:
- 1st row: indicate GPS state (4 leds)
- 2nd row: S1/S2 led indicate running state
- 3rd row: indicates battery state (7 leds)
- 4th row:
  - Tilt led indicates current (blink) or latched (steady) emergency
  - Cutting led is on while cutting and while docked
  - Battery led is burning steady on low
  - Charger connected led is blinking while charging, steady when charged

This PR requires fw-openmower-v2 PR #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CoverUI configuration section for YardForce500 hardware, including emergency channels for STOP and lift actions with configurable delay timings.
  * Introduced button-channel action mappings keyed by button ID to support UI states and press durations (short/long) for commands like start/pause/continue, abort mowing, docking/undocking, and emergency reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->