### PR TITLE
Properly shut down mower_comms_v2

### DIFF
--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -151,6 +151,7 @@ int main(int argc, char** argv) {
   std::string bind_ip = "0.0.0.0";
   paramNh.getParam("bind_ip", bind_ip);
   ROS_INFO_STREAM("Bind IP (Robot Internal): " << bind_ip);
+  xbot::serviceif::SetShutdownCallback([] { ros::requestShutdown(); });
   ctx = xbot::serviceif::Start(true, bind_ip);
 
   // Emergency service
@@ -296,6 +297,7 @@ int main(int argc, char** argv) {
   high_level_service->Start();
 
   ros::spin();
+  xbot::serviceif::Stop();
 
   return 0;
 }


### PR DESCRIPTION
xbot::serviceif registers a signal handler which "steals" the normal ROS signal handler that triggers ros::shutdown().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the framework dependency snapshot used by the project.
* **Bug Fixes**
  * Improved shutdown handling so the communication service layer is explicitly stopped during application exit, helping prevent lingering processes and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->