### PR TITLE
fix: publish version to external MQTT broker (fixes #301)

### DIFF
--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -270,7 +270,7 @@ void publish_version() {
     try_publish("version/json", version.dump(), true);
     if(external_mqtt_enable) {
         try {
-            client_external_->publish(external_mqtt_topic_prefix + "version", ersion.dump(), 1, true);
+            client_external_->publish(external_mqtt_topic_prefix + "version", version.dump(), 1, true);
             
         } catch (const mqtt::exception &e) {
             // client disconnected or something, we drop it.

--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -268,6 +268,14 @@ void publish_version() {
             {"version", version_string}
     };
     try_publish("version/json", version.dump(), true);
+    if(external_mqtt_enable) {
+        try {
+            client_external_->publish(external_mqtt_topic_prefix + "version", ersion.dump(), 1, true);
+            
+        } catch (const mqtt::exception &e) {
+            // client disconnected or something, we drop it.
+        }
+    }
     auto bson = json::to_bson(version);
     try_publish_binary("version", bson.data(), bson.size(), true);
 }


### PR DESCRIPTION
Fixes [#301](https://github.com/ClemensElflein/open_mower_ros/issues/301).

The `version` topic was published only via `try_publish_binary()`, which doesn't publish to the external broker (unlike `try_publish()`). So the external broker (e.g. Home Assistant) kept a stale retained value after upgrades.

This makes `publish_version()` also publish the version as JSON to the external broker, so it always reflects the current value.

*Note: this summary was written by Claude AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version information is now published to external MQTT brokers when external monitoring is enabled, providing broader system integration for monitoring purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->