### PR TITLE
Add Emergency and Skip-Path/Area for Series-I

### DIFF
--- a/src/open_mower/params/hardware_specific/Sabo/inputs.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/inputs.yaml
@@ -52,16 +52,22 @@ sabo:
     id: play
     actions:
       idle/short: "mower_logic:idle/start_mowing"
-      mowing/short: "mower_logic:mowing/pause"
-      paused/short: "mower_logic:mowing/continue"
-      mowing/long: "mower_logic/reset_emergency"
       idle/long: "mower_logic/reset_emergency"
+      mowing/short: "mower_logic:mowing/pause"
+      mowing/long: "mower_logic/reset_emergency"
+      paused/short: "mower_logic:mowing/continue"
+      paused/long: "mower_logic/reset_emergency"
       docking/long: "mower_logic/reset_emergency"
       area_recording/long: "mower_logic/reset_emergency"
 
   - name: Select button
     type: button
     id: select
+    actions:
+      mowing/short: "mower_logic:mowing/skip_path"
+      paused/short: "mower_logic:mowing/skip_path"
+      mowing/long: "mower_logic:mowing/skip_area"
+      paused/long: "mower_logic:mowing/skip_area"
 
   - name: Menu button
     type: button


### PR DESCRIPTION
This PR add better Clear-Emergency when in Mowing Mode and also add Skip-Path/Skip-Area button handling for Sabo Series-I mowers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added select button actions for mowing control (skip path and skip area functionality).

* **Bug Fixes**
  * Updated play button behavior to properly reset emergency states instead of continuing mowing in paused mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->