### PR TITLE
Disable "Start" button during rain.

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -28,6 +28,7 @@ extern void setGPS(bool enabled);
 extern void setRobotPose(geometry_msgs::Pose& pose);
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
 extern ros::Time rain_resume;
+extern bool rain_detected;
 
 extern ros::ServiceClient dockingPointClient;
 extern mower_msgs::Status getStatus();
@@ -85,6 +86,20 @@ Behavior* IdleBehavior::execute() {
     const bool rain_delay = last_config.rain_mode == 2 && ros::Time::now() < rain_resume;
     if (rain_delay) {
       ROS_INFO_STREAM_THROTTLE(300, "Rain delay: " << int((rain_resume - ros::Time::now()).toSec() / 60) << " minutes");
+    }
+
+    if (rain_detected && last_config.rain_mode) {
+      /* mower_logic would stop mowing immediately => disable "Start" button. */
+      if (actions[0].enabled) {
+        actions[0].enabled=false;
+        registerActions("mower_logic:idle", actions);
+      }
+    } else {
+      /* Dry conditions again => enable "Start" button */
+      if (!(actions[0].enabled)) {
+        actions[0].enabled=true;
+        registerActions("mower_logic:idle", actions);
+      }
     }
 
     // Use first valid sensor

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -28,7 +28,7 @@ extern void setGPS(bool enabled);
 extern void setRobotPose(geometry_msgs::Pose& pose);
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
 extern ros::Time rain_resume;
-extern bool rain_detected;
+extern std::atomic<bool> rain_detected;
 
 extern ros::ServiceClient dockingPointClient;
 extern mower_msgs::Status getStatus();
@@ -153,8 +153,9 @@ void IdleBehavior::enter() {
   // disable it, so that we don't start mowing immediately
   manual_start_mowing = false;
 
-  for (auto& a : actions) {
-    a.enabled = true;
+  actions[0].enabled=rain_detected && getConfig().rain_mode;
+  for (int i=actions.size(); --i>0; ) {
+    actions[i].enabled = true;
   }
   registerActions("mower_logic:idle", actions);
 }

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -91,13 +91,13 @@ Behavior* IdleBehavior::execute() {
     if (rain_detected && last_config.rain_mode) {
       /* mower_logic would stop mowing immediately => disable "Start" button. */
       if (actions[0].enabled) {
-        actions[0].enabled=false;
+        actions[0].enabled = false;
         registerActions("mower_logic:idle", actions);
       }
     } else {
       /* Dry conditions again => enable "Start" button */
       if (!(actions[0].enabled)) {
-        actions[0].enabled=true;
+        actions[0].enabled = true;
         registerActions("mower_logic:idle", actions);
       }
     }
@@ -153,8 +153,8 @@ void IdleBehavior::enter() {
   // disable it, so that we don't start mowing immediately
   manual_start_mowing = false;
 
-  actions[0].enabled=rain_detected && getConfig().rain_mode;
-  for (int i=actions.size(); --i>0; ) {
+  actions[0].enabled = rain_detected && getConfig().rain_mode;
+  for (int i = actions.size(); --i > 0;) {
     actions[i].enabled = true;
   }
   registerActions("mower_logic:idle", actions);

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -96,7 +96,7 @@ ros::Time last_v_battery_check;
 double max_v_battery_seen = 0.0;
 
 ros::Time last_rain_check;
-bool rain_detected = true;
+std::atomic<bool> rain_detected(true);
 ros::Time rain_resume;
 
 /**


### PR DESCRIPTION
Don't enable the "Start" button, if mower_logic would dock immediately because of rain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated rain-safety enforcement: when rain mode is enabled and rain is detected, the “Start Mowing” action is disabled to prevent operation in wet conditions.
  * When rain clears, the “Start Mowing” action is automatically re-enabled to allow operation to resume without manual intervention.
  * Rain detection handling is now safer under concurrent timer updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->