### PR TITLE
Add yf_cover_ui supoort for V2 hardware Again

### DIFF
--- a/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
+++ b/src/open_mower/params/hardware_specific/YardForce500/inputs.yaml
@@ -26,3 +26,85 @@ gpio:
     emergency:
       reason: stop
       delay: 10
+
+yf_cover_ui:
+  # ---- Emergency channels ----
+  # These directly reflect the Emergency_state bitmask received from the CoverUI panel.
+  # stop1 / stop2 are the STOP buttons on the CoverUI panel.
+  # lift / liftx are the lift sensors reported by the CoverUI panel.
+  # Note: the GPIO inputs above may detect the same physical events via different hardware paths.
+
+  - name: CoverUI stop button 1
+    channel: stop1
+    emergency:
+      reason: stop
+      delay: 10
+
+  - name: CoverUI stop button 2
+    channel: stop2
+    emergency:
+      reason: stop
+      delay: 10
+
+  - name: CoverUI lift sensor 1
+    channel: lift
+    emergency:
+      reason: lift
+      delay: 100
+
+  - name: CoverUI lift sensor 2
+    channel: liftx
+    emergency:
+      reason: lift
+      delay: 100
+
+  # ---- Button channels ----
+  # button_id values match those sent by the YardForce 500 CoverUI panel firmware.
+  # See old firmware mower_comms.cpp handleLowLevelUIEvent() for reference.
+
+  - name: CoverUI Home/docking button
+    channel: button
+    button_id: 2
+    actions:
+      mowing/short: "mower_logic:mowing/abort_mowing"
+      paused/short: "mower_logic:mowing/abort_mowing"
+
+  - name: CoverUI play/start button
+    channel: button
+    button_id: 3
+    actions:
+      idle/short: "mower_logic:idle/start_mowing"
+      mowing/short: "mower_logic:mowing/pause"
+      paused/short: "mower_logic:mowing/continue"
+      idle/long: "mower_logic/reset_emergency"
+      mowing/long: "mower_logic/reset_emergency"
+      paused/long: "mower_logic/reset_emergency"
+      docking/long: "mower_logic/reset_emergency"
+      undocking/long: "mower_logic/reset_emergency"
+      area_recording/long: "mower_logic/reset_emergency"
+
+  - name: CoverUI S1 button
+    channel: button
+    button_id: 4
+    actions:
+      idle/short: "mower_logic:idle/start_mowing"
+      mowing/short: "mower_logic:mowing/pause"
+      paused/short: "mower_logic:mowing/continue"
+
+  - name: CoverUI S2/home button
+    channel: button
+    button_id: 5
+    actions:
+      mowing/short: "mower_logic:mowing/abort_mowing"
+      paused/short: "mower_logic:mowing/abort_mowing"
+
+  - name: CoverUI lock/reset button (long press)
+    channel: button
+    button_id: 6
+    actions:
+      idle/long: "mower_logic/reset_emergency"
+      mowing/long: "mower_logic/reset_emergency"
+      paused/long: "mower_logic/reset_emergency"
+      docking/long: "mower_logic/reset_emergency"
+      undocking/long: "mower_logic/reset_emergency"
+      area_recording/long: "mower_logic/reset_emergency"


### PR DESCRIPTION
Adds yf_cover_ui support again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced emergency stop and hardware button input configuration for the YardForce 500.
  * Button presses and hold durations can now be mapped to key mowing behaviors (start/pause/continue/abort) as well as docking and emergency reset.
  * Emergency inputs include configurable reasons and response delays to better distinguish between stop and lift-related events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->