### PR TITLE
Add power service log_debug param; read params inside service interfaces

### DIFF
--- a/src/mower_comms_v2/src/DiffDriveServiceInterface.h
+++ b/src/mower_comms_v2/src/DiffDriveServiceInterface.h
@@ -17,17 +17,33 @@ class DiffDriveServiceInterface : public DiffDriveServiceInterfaceBase {
   DiffDriveServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx,
                             const ros::Publisher& actual_twist_publisher,
                             const ros::Publisher& left_esc_status_publisher,
-                            const ros::Publisher& right_esc_status_publisher, double ticks_per_meter,
-                            double wheel_distance)
+                            const ros::Publisher& right_esc_status_publisher, const ros::NodeHandle& param_nh)
       : DiffDriveServiceInterfaceBase(service_id, ctx),
         actual_twist_publisher_(actual_twist_publisher),
         left_esc_status_publisher_(left_esc_status_publisher),
-        right_esc_status_publisher_(right_esc_status_publisher),
-        wheel_distance_(wheel_distance),
-        ticks_per_meter_(ticks_per_meter) {
+        right_esc_status_publisher_(right_esc_status_publisher) {
+    if (!param_nh.getParam("services/diff_drive/ticks_per_m", ticks_per_meter_)) {
+      ROS_ERROR("Need to provide param services/diff_drive/ticks_per_m");
+      param_error_ = 1;
+      return;
+    }
+    if (!param_nh.getParam("services/diff_drive/wheel_distance_m", wheel_distance_)) {
+      ROS_ERROR("Need to provide param services/diff_drive/wheel_distance_m");
+      param_error_ = 1;
+      return;
+    }
+    ROS_INFO_STREAM("Wheel ticks [1/m]: " << ticks_per_meter_);
+    ROS_INFO_STREAM("Wheel distance [m]: " << wheel_distance_);
   }
 
   bool OnConfigurationRequested(uint16_t service_id) override;
+
+  /**
+   * Exit code for missing required parameters (0 = parameters valid).
+   */
+  int GetParamError() const {
+    return param_error_;
+  }
 
   /**
    * Convenience function to transmit the twist from a ROS message
@@ -64,8 +80,9 @@ class DiffDriveServiceInterface : public DiffDriveServiceInterfaceBase {
   const ros::Publisher& actual_twist_publisher_;
   const ros::Publisher& left_esc_status_publisher_;
   const ros::Publisher& right_esc_status_publisher_;
-  double wheel_distance_;
-  double ticks_per_meter_;
+  double wheel_distance_ = 0.0;
+  double ticks_per_meter_ = 0.0;
+  int param_error_ = 0;
 
   // Store the latest ESC state
   mower_msgs::ESCStatus left_esc_state_{};

--- a/src/mower_comms_v2/src/GpsServiceInterface.cpp
+++ b/src/mower_comms_v2/src/GpsServiceInterface.cpp
@@ -15,16 +15,39 @@
 
 GpsServiceInterface::GpsServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx,
                                          const ros::Publisher& absolute_pose_publisher,
-                                         const ros::Publisher& nmea_publisher, double datum_lat, double datum_long,
-                                         double datum_height, uint32_t baud_rate, const std::string& protocol,
-                                         uint8_t port_index, bool absolute_coords)
+                                         const ros::Publisher& nmea_publisher, const ros::NodeHandle& param_nh)
     : GpsServiceInterfaceBase(service_id, ctx),
       absolute_pose_publisher_(absolute_pose_publisher),
-      nmea_publisher_(nmea_publisher),
-      baud_rate_(baud_rate),
-      protocol_(protocol),
-      port_index_(port_index),
-      absolute_coords_(absolute_coords) {
+      nmea_publisher_(nmea_publisher) {
+  int baud_rate = 0;
+  param_nh.getParam("services/gps/baud_rate", baud_rate);
+  param_nh.getParam("services/gps/protocol", protocol_);
+  int port_index = 0;
+  param_nh.getParam("services/gps/port_index", port_index);
+  if (baud_rate == 0 || protocol_.empty()) {
+    ROS_ERROR("Need to specify GPS protocol and baud rate!");
+    param_error_ = 1;
+    return;
+  }
+  baud_rate_ = baud_rate;
+  port_index_ = port_index;
+  ROS_INFO_STREAM("GPS protocol: " << protocol_ << ", baud rate: " << baud_rate_
+                                   << ", gps port index:" << static_cast<int>(port_index_));
+
+  double datum_lat, datum_long, datum_height;
+  bool has_datum = true;
+  has_datum &= param_nh.getParam("services/gps/datum_lat", datum_lat);
+  has_datum &= param_nh.getParam("services/gps/datum_long", datum_long);
+  has_datum &= param_nh.getParam("services/gps/datum_height", datum_height);
+  if (!has_datum) {
+    ROS_ERROR_STREAM("You need to provide datum_lat and datum_long and datum_height in order to use the absolute mode");
+    param_error_ = 2;
+    return;
+  }
+  ROS_INFO_STREAM("Datum: " << datum_lat << ", " << datum_long << ", " << datum_height);
+
+  param_nh.getParam("services/gps/absolute_coords", absolute_coords_);
+
   RobotLocalization::NavsatConversions::LLtoUTM(datum_lat, datum_long, datum_n_, datum_e_, datum_zone_);
   datum_u_ = datum_height;
 }

--- a/src/mower_comms_v2/src/GpsServiceInterface.h
+++ b/src/mower_comms_v2/src/GpsServiceInterface.h
@@ -4,7 +4,7 @@
 
 #ifndef GPSSERVICEINTERFACE_H
 #define GPSSERVICEINTERFACE_H
-#include <ros/publisher.h>
+#include <ros/ros.h>
 #include <xbot_msgs/AbsolutePose.h>
 
 #include <GpsServiceInterfaceBase.hpp>
@@ -12,10 +12,16 @@
 class GpsServiceInterface : public GpsServiceInterfaceBase {
  public:
   GpsServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::Publisher& imu_publisher,
-                      const ros::Publisher& nmea_publisher, double datum_lat, double datum_long, double datum_height,
-                      uint32_t baud_rate, const std::string& protocol, uint8_t port_index, bool absolute_coords);
+                      const ros::Publisher& nmea_publisher, const ros::NodeHandle& param_nh);
 
   bool OnConfigurationRequested(uint16_t service_id) override;
+
+  /**
+   * Exit code for missing required parameters (0 = parameters valid).
+   */
+  int GetParamError() const {
+    return param_error_;
+  }
 
  protected:
   void OnPositionChanged(const double* new_value, uint32_t length) override;
@@ -33,9 +39,10 @@ class GpsServiceInterface : public GpsServiceInterfaceBase {
   const ros::Publisher& nmea_publisher_;
 
   std::string protocol_;
-  uint32_t baud_rate_;
-  uint8_t port_index_;
-  bool absolute_coords_;
+  uint32_t baud_rate_ = 0;
+  uint8_t port_index_ = 0;
+  bool absolute_coords_ = true;
+  int param_error_ = 0;
 
   xbot_msgs::AbsolutePose pose_msg_{};
   double datum_e_, datum_n_, datum_u_;

--- a/src/mower_comms_v2/src/GpsServiceInterface.h
+++ b/src/mower_comms_v2/src/GpsServiceInterface.h
@@ -11,8 +11,9 @@
 
 class GpsServiceInterface : public GpsServiceInterfaceBase {
  public:
-  GpsServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::Publisher& imu_publisher,
-                      const ros::Publisher& nmea_publisher, const ros::NodeHandle& param_nh);
+  GpsServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx,
+                      const ros::Publisher& absolute_pose_publisher, const ros::Publisher& nmea_publisher,
+                      const ros::NodeHandle& param_nh);
 
   bool OnConfigurationRequested(uint16_t service_id) override;
 

--- a/src/mower_comms_v2/src/ImuServiceInterface.h
+++ b/src/mower_comms_v2/src/ImuServiceInterface.h
@@ -5,7 +5,7 @@
 #ifndef IMUSERVICEINTERFACE_H
 #define IMUSERVICEINTERFACE_H
 
-#include <ros/publisher.h>
+#include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 
 #include <ImuServiceInterfaceBase.hpp>
@@ -13,8 +13,10 @@
 class ImuServiceInterface : public ImuServiceInterfaceBase {
  public:
   ImuServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::Publisher& imu_publisher,
-                      const std::string& axis_config)
-      : ImuServiceInterfaceBase(service_id, ctx), imu_publisher_(imu_publisher), axis_config_(axis_config) {
+                      const ros::NodeHandle& param_nh)
+      : ImuServiceInterfaceBase(service_id, ctx), imu_publisher_(imu_publisher) {
+    param_nh.getParam("services/imu/axis_config", axis_config_);
+    ROS_INFO_STREAM("IMU axis config: " << axis_config_);
   }
 
   bool OnConfigurationRequested(uint16_t service_id) override;

--- a/src/mower_comms_v2/src/InputServiceInterface.h
+++ b/src/mower_comms_v2/src/InputServiceInterface.h
@@ -10,10 +10,10 @@ using json = nlohmann::ordered_json;
 
 class InputServiceInterface : public InputServiceInterfaceBase {
  public:
-  InputServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, std::string config_file,
+  InputServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::NodeHandle& param_nh,
                         ros::Publisher action_pub)
       : InputServiceInterfaceBase(service_id, ctx),
-        config_file_(config_file),
+        config_file_(param_nh.param<std::string>("services/input/config_file", "")),
         action_pub_(action_pub),
         current_context_("idle") {
     ros::NodeHandle nh;

--- a/src/mower_comms_v2/src/InputServiceInterface.h
+++ b/src/mower_comms_v2/src/InputServiceInterface.h
@@ -10,12 +10,12 @@ using json = nlohmann::ordered_json;
 
 class InputServiceInterface : public InputServiceInterfaceBase {
  public:
-  InputServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, std::string config_file,
-                        int lift_multiple_delay, int collision_multiple_delay, ros::Publisher action_pub)
+  InputServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::NodeHandle& param_nh,
+                        ros::Publisher action_pub)
       : InputServiceInterfaceBase(service_id, ctx),
-        config_file_(config_file),
-        lift_multiple_delay_(lift_multiple_delay),
-        collision_multiple_delay_(collision_multiple_delay),
+        config_file_(param_nh.param<std::string>("services/input/config_file", "")),
+        lift_multiple_delay_(param_nh.param("services/input/lift_multiple_delay", -1)),
+        collision_multiple_delay_(param_nh.param("services/input/collision_multiple_delay", -1)),
         action_pub_(action_pub),
         current_context_("idle") {
     ros::NodeHandle nh;

--- a/src/mower_comms_v2/src/MetaServiceInterface.h
+++ b/src/mower_comms_v2/src/MetaServiceInterface.h
@@ -22,11 +22,14 @@ struct FirmwareInfo {
 class MetaServiceInterface : public MetaServiceInterfaceBase {
  public:
   MetaServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx, const ros::NodeHandle& nh,
-                       const std::string& firmware_name, std::function<void(const FirmwareInfo&)> version_callback)
+                       const ros::NodeHandle& param_nh, std::function<void(const FirmwareInfo&)> version_callback)
       : MetaServiceInterfaceBase(service_id, ctx),
         nh_(nh),
-        firmware_name_(firmware_name),
+        firmware_name_(param_nh.param<std::string>("board", "")),
         version_callback_(std::move(version_callback)) {
+    if (firmware_name_.empty()) {
+      ROS_WARN("No ll/board set. Stage-2 robots (other than Sabo or xBot) will not auto-configure!");
+    }
     // Periodic timer that polls the firmware version. Runs on the ROS (separate
     // spinner) thread until StopFirmwareCheck() is called or the service disconnects.
     firmware_check_timer_ = nh_.createTimer(

--- a/src/mower_comms_v2/src/PowerServiceInterface.cpp
+++ b/src/mower_comms_v2/src/PowerServiceInterface.cpp
@@ -66,6 +66,7 @@ bool PowerServiceInterface::OnConfigurationRequested(uint16_t service_id) {
   }
   if (system_current_ > 0.0f) SetRegisterSystemCurrent(system_current_);
   SetRegisterDangerouslyOverrideHardwareChargeCurrentLimit(override_hardware_charge_current_limit_ ? 1 : 0);
+  SetRegisterLogDebug(log_debug_ ? 1 : 0);
   CommitTransaction();
   return true;
 }

--- a/src/mower_comms_v2/src/PowerServiceInterface.h
+++ b/src/mower_comms_v2/src/PowerServiceInterface.h
@@ -24,7 +24,8 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
                         const ros::Publisher& status_publisher, float battery_full_voltage, float battery_empty_voltage,
                         float battery_critical_voltage, float battery_critical_high_voltage, float charge_voltage,
                         float charge_current, float charge_termination_current, float charge_precharge_current,
-                        int charge_recharge_voltage, float system_current, bool override_hardware_charge_current_limit)
+                        int charge_recharge_voltage, float system_current, bool override_hardware_charge_current_limit,
+                        bool log_debug)
       : PowerServiceInterfaceBase(service_id, ctx),
         status_publisher_(status_publisher),
         battery_full_voltage_(battery_full_voltage),
@@ -37,7 +38,8 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
         charge_precharge_current_(charge_precharge_current),
         charge_recharge_voltage_(charge_recharge_voltage),
         system_current_(system_current),
-        override_hardware_charge_current_limit_(override_hardware_charge_current_limit) {
+        override_hardware_charge_current_limit_(override_hardware_charge_current_limit),
+        log_debug_(log_debug) {
   }
 
  protected:
@@ -71,6 +73,7 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
   int charge_recharge_voltage_;
   float system_current_;
   bool override_hardware_charge_current_limit_;
+  bool log_debug_;
 };
 
 #endif  // POWERSERVICEINTERFACE_H

--- a/src/mower_comms_v2/src/PowerServiceInterface.h
+++ b/src/mower_comms_v2/src/PowerServiceInterface.h
@@ -12,7 +12,7 @@
 #define POWERSERVICEINTERFACE_H
 
 #include <mower_msgs/Power.h>
-#include <ros/publisher.h>
+#include <ros/ros.h>
 
 #include <PowerServiceInterfaceBase.hpp>
 #include <array>
@@ -21,25 +21,49 @@
 class PowerServiceInterface : public PowerServiceInterfaceBase {
  public:
   PowerServiceInterface(uint16_t service_id, const xbot::serviceif::Context& ctx,
-                        const ros::Publisher& status_publisher, float battery_full_voltage, float battery_empty_voltage,
-                        float battery_critical_voltage, float battery_critical_high_voltage, float charge_voltage,
-                        float charge_current, float charge_termination_current, float charge_precharge_current,
-                        int charge_recharge_voltage, float system_current, bool override_hardware_charge_current_limit,
-                        bool log_debug)
-      : PowerServiceInterfaceBase(service_id, ctx),
-        status_publisher_(status_publisher),
-        battery_full_voltage_(battery_full_voltage),
-        battery_empty_voltage_(battery_empty_voltage),
-        battery_critical_voltage_(battery_critical_voltage),
-        battery_critical_high_voltage_(battery_critical_high_voltage),
-        charge_voltage_(charge_voltage),
-        charge_current_(charge_current),
-        charge_termination_current_(charge_termination_current),
-        charge_precharge_current_(charge_precharge_current),
-        charge_recharge_voltage_(charge_recharge_voltage),
-        system_current_(system_current),
-        override_hardware_charge_current_limit_(override_hardware_charge_current_limit),
-        log_debug_(log_debug) {
+                        const ros::Publisher& status_publisher, const ros::NodeHandle& param_nh)
+      : PowerServiceInterfaceBase(service_id, ctx), status_publisher_(status_publisher) {
+    // Mainly for monitoring and informational purposes
+    if (!param_nh.getParam("services/power/battery_full_voltage", battery_full_voltage_)) {
+      ROS_ERROR("Need to set param: services/power/battery_full_voltage");
+      param_error_ = 1;
+      return;
+    }
+    if (!param_nh.getParam("services/power/battery_empty_voltage", battery_empty_voltage_)) {
+      ROS_ERROR("Need to set param: services/power/battery_empty_voltage");
+      param_error_ = 1;
+      return;
+    }
+    if (!param_nh.getParam("services/power/battery_critical_voltage", battery_critical_voltage_)) {
+      ROS_ERROR("Need to set param: services/power/battery_critical_voltage");
+      param_error_ = 1;
+      return;
+    }
+    if (!param_nh.getParam("services/power/battery_critical_high_voltage", battery_critical_high_voltage_)) {
+      ROS_ERROR("Need to set param: services/power/battery_critical_high_voltage");
+      param_error_ = 1;
+      return;
+    }
+
+    // Optional charger configuration
+    param_nh.getParam("services/power/charge_voltage", charge_voltage_);
+    param_nh.getParam("services/power/charge_current", charge_current_);
+    param_nh.getParam("services/power/charge_termination_current", charge_termination_current_);
+    param_nh.getParam("services/power/charge_pre_charge_current", charge_precharge_current_);
+    param_nh.getParam("services/power/charge_re_charge_voltage", charge_recharge_voltage_);
+
+    // Optional settings also required for charger DPM (dynamic power management)
+    param_nh.getParam("services/power/system_current", system_current_);
+    param_nh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
+                      override_hardware_charge_current_limit_);
+    param_nh.getParam("services/power/log_debug", log_debug_);
+  }
+
+  /**
+   * Exit code for missing required parameters (0 = parameters valid).
+   */
+  int GetParamError() const {
+    return param_error_;
   }
 
  protected:
@@ -62,18 +86,19 @@ class PowerServiceInterface : public PowerServiceInterfaceBase {
   mower_msgs::Power power_msg_{};
   const ros::Publisher& status_publisher_;
 
-  float battery_full_voltage_;
-  float battery_empty_voltage_;
-  float battery_critical_voltage_;
-  float battery_critical_high_voltage_;
-  float charge_voltage_;
-  float charge_current_;
-  float charge_termination_current_;
-  float charge_precharge_current_;
-  int charge_recharge_voltage_;
-  float system_current_;
-  bool override_hardware_charge_current_limit_;
-  bool log_debug_;
+  float battery_full_voltage_ = 0.0f;
+  float battery_empty_voltage_ = 0.0f;
+  float battery_critical_voltage_ = 0.0f;
+  float battery_critical_high_voltage_ = 0.0f;
+  float charge_voltage_ = -1.0f;
+  float charge_current_ = -1.0f;
+  float charge_termination_current_ = -1.0f;
+  float charge_precharge_current_ = -1.0f;
+  int charge_recharge_voltage_ = -1;
+  float system_current_ = -1.0f;  // Max. current allowed to be drawn from wall AC/DC
+  bool override_hardware_charge_current_limit_ = false;
+  bool log_debug_ = false;
+  int param_error_ = 0;
 };
 
 #endif  // POWERSERVICEINTERFACE_H

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -239,10 +239,12 @@ int main(int argc, char** argv) {
   bool override_hw_charge_current_limit = false;
   paramNh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
                    override_hw_charge_current_limit);
+  bool log_debug = false;
+  paramNh.getParam("services/power/log_debug", log_debug);
   power_service = std::make_unique<PowerServiceInterface>(
       xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
       battery_critical_high_voltage, charge_voltage, charge_current, charge_termination_current,
-      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit);
+      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit, log_debug);
   power_service->Start();
 
   // BMS service

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -148,39 +148,9 @@ int main(int argc, char** argv) {
   actual_twist_pub = n.advertise<geometry_msgs::TwistStamped>("ll/diff_drive/measured_twist", 1);
   status_left_esc_pub = n.advertise<mower_msgs::ESCStatus>("ll/diff_drive/left_esc_status", 1);
   status_right_esc_pub = n.advertise<mower_msgs::ESCStatus>("ll/diff_drive/right_esc_status", 1);
-  double wheel_ticks_per_m = 0.0;
-  double wheel_distance_m = 0.0;
-  if (!paramNh.getParam("services/diff_drive/ticks_per_m", wheel_ticks_per_m)) {
-    ROS_ERROR("Need to provide param services/diff_drive/ticks_per_m");
-    return 1;
-  }
-  if (!paramNh.getParam("services/diff_drive/wheel_distance_m", wheel_distance_m)) {
-    ROS_ERROR("Need to provide param services/diff_drive/wheel_distance_m");
-    return 1;
-  }
-  ROS_INFO_STREAM("Wheel ticks [1/m]: " << wheel_ticks_per_m);
-  ROS_INFO_STREAM("Wheel distance [m]: " << wheel_distance_m);
-
-  int baud_rate = 0;
-  paramNh.getParam("services/gps/baud_rate", baud_rate);
-
-  std::string protocol;
-  paramNh.getParam("services/gps/protocol", protocol);
-
-  int gps_port_index = 0;
-  paramNh.getParam("services/gps/port_index", gps_port_index);
-
-  if (baud_rate == 0 || protocol.empty()) {
-    ROS_ERROR("Need to specify GPS protocol and baud rate!");
-    return 1;
-  }
-
-  ROS_INFO_STREAM("GPS protocol: " << protocol << ", baud rate: " << baud_rate
-                                   << ", gps port index:" << gps_port_index);
-
   diff_drive_service = std::make_unique<DiffDriveServiceInterface>(xbot::service_ids::DIFF_DRIVE, ctx, actual_twist_pub,
-                                                                   status_left_esc_pub, status_right_esc_pub,
-                                                                   wheel_ticks_per_m, wheel_distance_m);
+                                                                   status_left_esc_pub, status_right_esc_pub, paramNh);
+  if (int err = diff_drive_service->GetParamError()) return err;
   diff_drive_service->Start();
 
   // Mower service
@@ -189,62 +159,14 @@ int main(int argc, char** argv) {
   mower_service->Start();
 
   // IMU service
-  std::string imu_axis_config;
-  paramNh.getParam("services/imu/axis_config", imu_axis_config);
-  ROS_INFO_STREAM("IMU axis config: " << imu_axis_config);
   sensor_imu_pub = n.advertise<sensor_msgs::Imu>("ll/imu/data_raw", 1);
-  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub, imu_axis_config);
+  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub, paramNh);
   imu_service->Start();
 
   // Power service
   power_pub = n.advertise<mower_msgs::Power>("ll/power", 1);
-
-  // Mainly for monitoring and informational purposes
-  float battery_full_voltage;
-  float battery_empty_voltage;
-  float battery_critical_voltage;
-  float battery_critical_high_voltage;
-  if (!paramNh.getParam("services/power/battery_full_voltage", battery_full_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_full_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_empty_voltage", battery_empty_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_empty_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_critical_voltage", battery_critical_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_critical_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_critical_high_voltage", battery_critical_high_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_critical_high_voltage");
-    return 1;
-  }
-
-  // Optional charger configuration
-  float charge_voltage = -1.0f;
-  float charge_current = -1.0f;
-  float charge_termination_current = -1.0f;
-  float charge_precharge_current = -1.0f;
-  int charge_recharge_voltage = -1;
-  paramNh.getParam("services/power/charge_voltage", charge_voltage);
-  paramNh.getParam("services/power/charge_current", charge_current);
-  paramNh.getParam("services/power/charge_termination_current", charge_termination_current);
-  paramNh.getParam("services/power/charge_pre_charge_current", charge_precharge_current);
-  paramNh.getParam("services/power/charge_re_charge_voltage", charge_recharge_voltage);
-
-  // Optional settings also required for charger DPM (dynamic power management)
-  float system_current = -1.0f;  // Max. current allowed to be drawn from wall AC/DC
-  paramNh.getParam("services/power/system_current", system_current);
-  bool override_hw_charge_current_limit = false;
-  paramNh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
-                   override_hw_charge_current_limit);
-  bool log_debug = false;
-  paramNh.getParam("services/power/log_debug", log_debug);
-  power_service = std::make_unique<PowerServiceInterface>(
-      xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
-      battery_critical_high_voltage, charge_voltage, charge_current, charge_termination_current,
-      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit, log_debug);
+  power_service = std::make_unique<PowerServiceInterface>(xbot::service_ids::POWER, ctx, power_pub, paramNh);
+  if (int err = power_service->GetParamError()) return err;
   power_service->Start();
 
   // BMS service
@@ -253,31 +175,15 @@ int main(int argc, char** argv) {
   bms_service->Start();
 
   // GPS service
-  double datum_lat, datum_long, datum_height;
-  bool has_datum = true;
-  has_datum &= paramNh.getParam("services/gps/datum_lat", datum_lat);
-  has_datum &= paramNh.getParam("services/gps/datum_long", datum_long);
-  has_datum &= paramNh.getParam("services/gps/datum_height", datum_height);
-  if (!has_datum) {
-    ROS_ERROR_STREAM("You need to provide datum_lat and datum_long and datum_height in order to use the absolute mode");
-    return 2;
-  }
-  ROS_INFO_STREAM("Datum: " << datum_lat << ", " << datum_long << ", " << datum_height);
   gps_position_pub = n.advertise<xbot_msgs::AbsolutePose>("ll/position/gps", 1);
   nmea_pub = n.advertise<nmea_msgs::Sentence>("ll/position/gps/nmea", 1);
-  bool absolute_coords = true;
-  paramNh.getParam("services/gps/absolute_coords", absolute_coords);
-  gps_service = std::make_unique<GpsServiceInterface>(xbot::service_ids::GPS, ctx, gps_position_pub, nmea_pub,
-                                                      datum_lat, datum_long, datum_height, baud_rate, protocol,
-                                                      gps_port_index, absolute_coords);
+  gps_service = std::make_unique<GpsServiceInterface>(xbot::service_ids::GPS, ctx, gps_position_pub, nmea_pub, paramNh);
+  if (int err = gps_service->GetParamError()) return err;
   gps_service->Start();
 
   // Input service
-  {
-    std::string config_file = paramNh.param<std::string>("services/input/config_file", "");
-    input_service = std::make_unique<InputServiceInterface>(xbot::service_ids::INPUT, ctx, config_file, action_pub);
-    input_service->Start();
-  }
+  input_service = std::make_unique<InputServiceInterface>(xbot::service_ids::INPUT, ctx, paramNh, action_pub);
+  input_service->Start();
 
   // HighLevel service
   high_level_service = std::make_unique<HighLevelServiceInterface>(xbot::service_ids::HIGH_LEVEL, ctx);

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -189,13 +189,8 @@ int main(int argc, char** argv) {
   // Start MetaService as early as possible, so the FW can exit its Stage-2 wait loop
   // Reads ll/board param; pushes it as RobotFirmware on every connect
   {
-    std::string board;
-    paramNh.getParam("board", board);
-    if (board.empty()) {
-      ROS_WARN("No ll/board set. Stage-2 robots (other than Sabo or xBot) will not auto-configure!");
-    }
     meta_service =
-        std::make_unique<MetaServiceInterface>(xbot::service_ids::META, ctx, n, board, OnFirmwareInfoChanged);
+        std::make_unique<MetaServiceInterface>(xbot::service_ids::META, ctx, n, paramNh, OnFirmwareInfoChanged);
     meta_service->Start();
   }
 

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -299,10 +299,12 @@ int main(int argc, char** argv) {
   bool override_hw_charge_current_limit = false;
   paramNh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
                    override_hw_charge_current_limit);
+  bool log_debug = false;
+  paramNh.getParam("services/power/log_debug", log_debug);
   power_service = std::make_unique<PowerServiceInterface>(
       xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
       battery_critical_high_voltage, charge_voltage, charge_current, charge_termination_current,
-      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit);
+      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit, log_debug);
   power_service->Start();
 
   // BMS service

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -208,39 +208,9 @@ int main(int argc, char** argv) {
   actual_twist_pub = n.advertise<geometry_msgs::TwistStamped>("ll/diff_drive/measured_twist", 1);
   status_left_esc_pub = n.advertise<mower_msgs::ESCStatus>("ll/diff_drive/left_esc_status", 1);
   status_right_esc_pub = n.advertise<mower_msgs::ESCStatus>("ll/diff_drive/right_esc_status", 1);
-  double wheel_ticks_per_m = 0.0;
-  double wheel_distance_m = 0.0;
-  if (!paramNh.getParam("services/diff_drive/ticks_per_m", wheel_ticks_per_m)) {
-    ROS_ERROR("Need to provide param services/diff_drive/ticks_per_m");
-    return 1;
-  }
-  if (!paramNh.getParam("services/diff_drive/wheel_distance_m", wheel_distance_m)) {
-    ROS_ERROR("Need to provide param services/diff_drive/wheel_distance_m");
-    return 1;
-  }
-  ROS_INFO_STREAM("Wheel ticks [1/m]: " << wheel_ticks_per_m);
-  ROS_INFO_STREAM("Wheel distance [m]: " << wheel_distance_m);
-
-  int baud_rate = 0;
-  paramNh.getParam("services/gps/baud_rate", baud_rate);
-
-  std::string protocol;
-  paramNh.getParam("services/gps/protocol", protocol);
-
-  int gps_port_index = 0;
-  paramNh.getParam("services/gps/port_index", gps_port_index);
-
-  if (baud_rate == 0 || protocol.empty()) {
-    ROS_ERROR("Need to specify GPS protocol and baud rate!");
-    return 1;
-  }
-
-  ROS_INFO_STREAM("GPS protocol: " << protocol << ", baud rate: " << baud_rate
-                                   << ", gps port index:" << gps_port_index);
-
   diff_drive_service = std::make_unique<DiffDriveServiceInterface>(xbot::service_ids::DIFF_DRIVE, ctx, actual_twist_pub,
-                                                                   status_left_esc_pub, status_right_esc_pub,
-                                                                   wheel_ticks_per_m, wheel_distance_m);
+                                                                   status_left_esc_pub, status_right_esc_pub, paramNh);
+  if (int err = diff_drive_service->GetParamError()) return err;
   diff_drive_service->Start();
 
   // Mower service
@@ -249,62 +219,14 @@ int main(int argc, char** argv) {
   mower_service->Start();
 
   // IMU service
-  std::string imu_axis_config;
-  paramNh.getParam("services/imu/axis_config", imu_axis_config);
-  ROS_INFO_STREAM("IMU axis config: " << imu_axis_config);
   sensor_imu_pub = n.advertise<sensor_msgs::Imu>("ll/imu/data_raw", 1);
-  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub, imu_axis_config);
+  imu_service = std::make_unique<ImuServiceInterface>(xbot::service_ids::IMU, ctx, sensor_imu_pub, paramNh);
   imu_service->Start();
 
   // Power service
   power_pub = n.advertise<mower_msgs::Power>("ll/power", 1);
-
-  // Mainly for monitoring and informational purposes
-  float battery_full_voltage;
-  float battery_empty_voltage;
-  float battery_critical_voltage;
-  float battery_critical_high_voltage;
-  if (!paramNh.getParam("services/power/battery_full_voltage", battery_full_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_full_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_empty_voltage", battery_empty_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_empty_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_critical_voltage", battery_critical_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_critical_voltage");
-    return 1;
-  }
-  if (!paramNh.getParam("services/power/battery_critical_high_voltage", battery_critical_high_voltage)) {
-    ROS_ERROR("Need to set param: services/power/battery_critical_high_voltage");
-    return 1;
-  }
-
-  // Optional charger configuration
-  float charge_voltage = -1.0f;
-  float charge_current = -1.0f;
-  float charge_termination_current = -1.0f;
-  float charge_precharge_current = -1.0f;
-  int charge_recharge_voltage = -1;
-  paramNh.getParam("services/power/charge_voltage", charge_voltage);
-  paramNh.getParam("services/power/charge_current", charge_current);
-  paramNh.getParam("services/power/charge_termination_current", charge_termination_current);
-  paramNh.getParam("services/power/charge_pre_charge_current", charge_precharge_current);
-  paramNh.getParam("services/power/charge_re_charge_voltage", charge_recharge_voltage);
-
-  // Optional settings also required for charger DPM (dynamic power management)
-  float system_current = -1.0f;  // Max. current allowed to be drawn from wall AC/DC
-  paramNh.getParam("services/power/system_current", system_current);
-  bool override_hw_charge_current_limit = false;
-  paramNh.getParam("services/power/dangerously_override_hardware_charge_current_limit",
-                   override_hw_charge_current_limit);
-  bool log_debug = false;
-  paramNh.getParam("services/power/log_debug", log_debug);
-  power_service = std::make_unique<PowerServiceInterface>(
-      xbot::service_ids::POWER, ctx, power_pub, battery_full_voltage, battery_empty_voltage, battery_critical_voltage,
-      battery_critical_high_voltage, charge_voltage, charge_current, charge_termination_current,
-      charge_precharge_current, charge_recharge_voltage, system_current, override_hw_charge_current_limit, log_debug);
+  power_service = std::make_unique<PowerServiceInterface>(xbot::service_ids::POWER, ctx, power_pub, paramNh);
+  if (int err = power_service->GetParamError()) return err;
   power_service->Start();
 
   // BMS service
@@ -313,34 +235,15 @@ int main(int argc, char** argv) {
   bms_service->Start();
 
   // GPS service
-  double datum_lat, datum_long, datum_height;
-  bool has_datum = true;
-  has_datum &= paramNh.getParam("services/gps/datum_lat", datum_lat);
-  has_datum &= paramNh.getParam("services/gps/datum_long", datum_long);
-  has_datum &= paramNh.getParam("services/gps/datum_height", datum_height);
-  if (!has_datum) {
-    ROS_ERROR_STREAM("You need to provide datum_lat and datum_long and datum_height in order to use the absolute mode");
-    return 2;
-  }
-  ROS_INFO_STREAM("Datum: " << datum_lat << ", " << datum_long << ", " << datum_height);
   gps_position_pub = n.advertise<xbot_msgs::AbsolutePose>("ll/position/gps", 1);
   nmea_pub = n.advertise<nmea_msgs::Sentence>("ll/position/gps/nmea", 1);
-  bool absolute_coords = true;
-  paramNh.getParam("services/gps/absolute_coords", absolute_coords);
-  gps_service = std::make_unique<GpsServiceInterface>(xbot::service_ids::GPS, ctx, gps_position_pub, nmea_pub,
-                                                      datum_lat, datum_long, datum_height, baud_rate, protocol,
-                                                      gps_port_index, absolute_coords);
+  gps_service = std::make_unique<GpsServiceInterface>(xbot::service_ids::GPS, ctx, gps_position_pub, nmea_pub, paramNh);
+  if (int err = gps_service->GetParamError()) return err;
   gps_service->Start();
 
   // Input service
-  {
-    std::string config_file = paramNh.param<std::string>("services/input/config_file", "");
-    int lift_multiple_delay = paramNh.param("services/input/lift_multiple_delay", -1);
-    int collision_multiple_delay = paramNh.param("services/input/collision_multiple_delay", -1);
-    input_service = std::make_unique<InputServiceInterface>(xbot::service_ids::INPUT, ctx, config_file,
-                                                            lift_multiple_delay, collision_multiple_delay, action_pub);
-    input_service->Start();
-  }
+  input_service = std::make_unique<InputServiceInterface>(xbot::service_ids::INPUT, ctx, paramNh, action_pub);
+  input_service->Start();
 
   // HighLevel service
   high_level_service = std::make_unique<HighLevelServiceInterface>(xbot::service_ids::HIGH_LEVEL, ctx);


### PR DESCRIPTION
## Summary
- Add `log_debug` parameter for the power service, wired from `services/power/log_debug` through `PowerServiceInterface` to the firmware `Log Debug` register (services submodule bumped to the commit that adds it).
- Refactor `mower_comms_v2`: hand the `/ll` NodeHandle to each service interface so it reads its own ROS params, instead of reading them one-by-one in `main()`.

## Notes
- Missing required params are reported via `GetParamError()`, preserving previous exit codes (1 for diff_drive/power/gps config, 2 for GPS datum).
- No functional change in the refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service interfaces now load drive, GPS, IMU, input, power, and board settings from the ROS parameter server.
  * Added configuration status reporting for required parameters.
  * Power configuration now records the log-debug setting during configuration.

* **Bug Fixes**
  * Services stop initialization when required configuration is missing or invalid, preventing operation with incomplete settings.
  * Improved error logging identifies configuration problems during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->