### PR TITLE
mower_comms_v2: drive the mow motor with a signed speed

### DIFF
--- a/src/mower_comms_v2/src/MowerServiceInterface.cpp
+++ b/src/mower_comms_v2/src/MowerServiceInterface.cpp
@@ -5,12 +5,14 @@
 #include "MowerServiceInterface.h"
 
 void MowerServiceInterface::Tick() {
-  SendMowerEnabled(status_msg_.mow_enabled);
+  SendMowerSpeed(commanded_speed_);
 }
 
-void MowerServiceInterface::SetMowerEnabled(bool enabled) {
-  SendMowerEnabled(enabled);
-  status_msg_.mow_enabled = enabled;
+void MowerServiceInterface::SetMowerSpeed(float speed) {
+  // Signed speed/duty in [-1, 1]: sign = direction, 0 = off.
+  commanded_speed_ = speed;
+  SendMowerSpeed(speed);
+  status_msg_.mow_enabled = speed != 0.0f;
   status_publisher_.publish(status_msg_);
 }
 
@@ -44,7 +46,9 @@ void MowerServiceInterface::OnMowerMotorRPMChanged(const float& new_value) {
 
 void MowerServiceInterface::OnServiceConnected(uint16_t service_id) {
   status_msg_ = {};
-  SendMowerEnabled(false);
+  // Clear the cached speed so a stale value isn't replayed after reconnect.
+  commanded_speed_ = 0.0f;
+  SendMowerSpeed(commanded_speed_);
 }
 
 void MowerServiceInterface::OnTransactionStart(uint64_t timestamp) {

--- a/src/mower_comms_v2/src/MowerServiceInterface.h
+++ b/src/mower_comms_v2/src/MowerServiceInterface.h
@@ -17,7 +17,7 @@ class MowerServiceInterface : public MowerServiceInterfaceBase {
       : MowerServiceInterfaceBase(service_id, ctx), status_publisher_(status_publisher) {
   }
 
-  void SetMowerEnabled(bool enabled);
+  void SetMowerSpeed(float speed);
 
   void Tick();
 
@@ -38,6 +38,7 @@ class MowerServiceInterface : public MowerServiceInterfaceBase {
  private:
   mower_msgs::Status status_msg_{};
   const ros::Publisher& status_publisher_;
+  float commanded_speed_ = 0.0f;  // commanded normalized speed in [-1, 1]; re-sent every tick
 };
 
 #endif  // MOWERSERVICEINTERFACE_H

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -100,7 +100,9 @@ void sendMowerEnabledTimerTask(const ros::TimerEvent& e) {
 }
 
 bool setMowEnabled(mower_msgs::MowerControlSrvRequest& req, mower_msgs::MowerControlSrvResponse& res) {
-  mower_service->SetMowerEnabled(req.mow_enabled);
+  // enable + direction -> signed speed: +1 forward, -1 reverse, 0 off.
+  const float speed = req.mow_enabled ? (req.mow_direction ? 1.0f : -1.0f) : 0.0f;
+  mower_service->SetMowerSpeed(speed);
   return true;
 }
 

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -44,5 +44,6 @@ gen.add("emergency_lift_period", int_t, 0, "Period (ms) for multiple wheels/hall
 gen.add("emergency_tilt_period", int_t, 0, "Period (ms) for a single wheel/hall to be lifted/triggered in order to count as emergency. This is to filter uneven ground", -1)
 gen.add("emergency_input_config", str_t, 0, "Comma separated list of emergency inputs (halls or stop), where each sensor can be configured in one of the following modes '[!]<I>gnore|<U>nused|<S>top|<L>Lift'", "")
 gen.add("shutdown_esc_max_pitch", int_t, 0, "Maximum pitch angle (deg) where ESC shutdown is permitted (0 to disable ESC shutdown)", 0, 0, 180)
+gen.add("randomize_mow_motor_direction", bool_t, 0, "Alternate the mow motor's rotation direction between runs to even out blade wear. Only enable for symmetric/reversible blades.", False)
 
 exit(gen.generate("mower_logic", "mower_logic", "MowerLogic"))

--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -18,6 +18,8 @@
 #include <mower_msgs/Power.h>
 #include <xbot_msgs/SensorDataString.h>
 
+#include <cmath>
+
 #include "mower_logic/MowerLogicConfig.h"
 #include "mower_logic/PowerConfig.h"
 #include "mower_logic/utils.h"
@@ -85,7 +87,7 @@ std::map<std::string, SensorConfig> sensor_configs{
   {"om_mow_esc_temp", {"Mow ESC Temp", "deg.C", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_esc_temperature; }, &set_limits_esc_temp, "mower_xesc"}},
   {"om_mow_motor_temp", {"Mow Motor Temp", "deg.C", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_motor_temperature; }, &set_limits_mow_motor_temp, "mower_xesc", [](){ return paramNh->param("mower_xesc/has_motor_temp", true); }}},
   {"om_mow_motor_current", {"Mow Motor Current", "A", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_CURRENT, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_esc_current; }, &set_limits_mow_motor_current, "mower_xesc"}},
-  {"om_mow_motor_rpm", {"Mow Motor Revolutions", "rpm", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_motor_rpm; }, &set_limits_mow_motor_rpm, "mower_xesc"}},
+  {"om_mow_motor_rpm", {"Mow Motor Revolutions", "rpm", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return std::fabs(msg->mower_motor_rpm); }, &set_limits_mow_motor_rpm, "mower_xesc"}},
   {"om_gps_accuracy", {"GPS Accuracy", "m", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_DISTANCE, xbot_msgs::SensorInfo::TYPE_DOUBLE}},
 };
 // clang-format on

--- a/src/mower_logic/src/monitoring/monitoring.cpp
+++ b/src/mower_logic/src/monitoring/monitoring.cpp
@@ -87,7 +87,7 @@ std::map<std::string, SensorConfig> sensor_configs{
   {"om_mow_esc_temp", {"Mow ESC Temp", "deg.C", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_esc_temperature; }, &set_limits_esc_temp, "mower_xesc"}},
   {"om_mow_motor_temp", {"Mow Motor Temp", "deg.C", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_TEMPERATURE, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_motor_temperature; }, &set_limits_mow_motor_temp, "mower_xesc", [](){ return paramNh->param("mower_xesc/has_motor_temp", true); }}},
   {"om_mow_motor_current", {"Mow Motor Current", "A", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_CURRENT, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_esc_current; }, &set_limits_mow_motor_current, "mower_xesc"}},
-  {"om_mow_motor_rpm", {"Mow Motor Revolutions", "rpm", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return std::fabs(msg->mower_motor_rpm); }, &set_limits_mow_motor_rpm, "mower_xesc"}},
+  {"om_mow_motor_rpm", {"Mow Motor Revolutions", "rpm", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_RPM, xbot_msgs::SensorInfo::TYPE_DOUBLE, [](StatusPtr msg) { return msg->mower_motor_rpm; }, &set_limits_mow_motor_rpm, "mower_xesc"}},
   {"om_gps_accuracy", {"GPS Accuracy", "m", xbot_msgs::SensorInfo::VALUE_DESCRIPTION_DISTANCE, xbot_msgs::SensorInfo::TYPE_DOUBLE}},
 };
 // clang-format on

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -274,7 +274,8 @@ bool setMowerEnabled(bool enabled) {
     ros::Time started = ros::Time::now();
     mower_msgs::MowerControlSrv mow_srv;
     mow_srv.request.mow_enabled = enabled;
-    mow_srv.request.mow_direction = started.sec & 0x1;  // Randomize mower direction on second
+    // Opt-in direction alternation; forward (1) by default.
+    mow_srv.request.mow_direction = last_config.randomize_mow_motor_direction ? (started.sec & 0x1) : 1;
     ROS_WARN_STREAM("#### om_mower_logic: setMowerEnabled("
                     << enabled << ", " << static_cast<unsigned>(mow_srv.request.mow_direction) << ") call");
 

--- a/src/mower_msgs/msg/Status.msg
+++ b/src/mower_msgs/msg/Status.msg
@@ -21,4 +21,4 @@ uint8   mower_esc_status
 float32 mower_esc_temperature
 float32 mower_esc_current
 float32 mower_motor_temperature
-float32 mower_motor_rpm
+float32 mower_motor_rpm  # signed: sign = spin direction, magnitude = rpm

--- a/src/mower_simulation/src/services/mower_service/mower_service.cpp
+++ b/src/mower_simulation/src/services/mower_service/mower_service.cpp
@@ -26,6 +26,6 @@ void MowerService::tick() {
   CommitTransaction();
 }
 
-void MowerService::OnMowerEnabledChanged(const uint8_t& new_value) {
-  mower_running_ = new_value;
+void MowerService::OnMowerSpeedChanged(const float& new_value) {
+  mower_running_ = new_value != 0.0f;
 }

--- a/src/mower_simulation/src/services/mower_service/mower_service.hpp
+++ b/src/mower_simulation/src/services/mower_service/mower_service.hpp
@@ -25,7 +25,7 @@ class MowerService : public MowerServiceBase {
 
  protected:
   bool OnStart() override;
-  void OnMowerEnabledChanged(const uint8_t& new_value) override;
+  void OnMowerSpeedChanged(const float& new_value) override;
 };
 
 #endif  // MOWER_SERVICE_HPP


### PR DESCRIPTION
Sends a single signed `Mower Speed` to the LL board (enable + direction mapped to +1 / -1 / 0), pairing with the firmware PR after the `MowerDirection` register was dropped (definitions #25, merged).

- Direction now rides on the sign of `mower_motor_rpm`; drops the separate `Status.mow_direction` field and its handler (monitoring takes `abs()`).
- Between-run direction randomization is now opt-in (`randomize_mow_motor_direction`, default off).
- Bumps the `services` submodule to the merged definitions (`c074039`).