### PR TITLE
Fix sim manual drive

### DIFF
--- a/docker-simulation/data/params/custom_params.yaml
+++ b/docker-simulation/data/params/custom_params.yaml
@@ -78,7 +78,6 @@ mower_logic:
   # Once you validated the functionality of your emergency sensors,
   # set this to true to enable the mow-motor
   enable_mower: false
-  always_allow_joystick: true
 
 xbot_monitoring:
   # For an external (e.g. Home Assistant) integration only - the app itself doesn't use

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -44,6 +44,5 @@ gen.add("emergency_lift_period", int_t, 0, "Period (ms) for multiple wheels/hall
 gen.add("emergency_tilt_period", int_t, 0, "Period (ms) for a single wheel/hall to be lifted/triggered in order to count as emergency. This is to filter uneven ground", -1)
 gen.add("emergency_input_config", str_t, 0, "Comma separated list of emergency inputs (halls or stop), where each sensor can be configured in one of the following modes '[!]<I>gnore|<U>nused|<S>top|<L>Lift'", "")
 gen.add("shutdown_esc_max_pitch", int_t, 0, "Maximum pitch angle (deg) where ESC shutdown is permitted (0 to disable ESC shutdown)", 0, 0, 180)
-gen.add("always_allow_joystick", bool_t, 0, "True to always forward joystick input regardless of current behavior (recommended for simulation)", False)
 
 exit(gen.generate("mower_logic", "mower_logic", "MowerLogic"))

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -701,7 +701,7 @@ void actionReceived(const std_msgs::String::ConstPtr& action) {
 
 void joyVelReceived(const geometry_msgs::Twist::ConstPtr& joy_vel) {
   joy_vel_time = ros::Time::now();
-  if (last_config.always_allow_joystick || (currentBehavior && currentBehavior->redirect_joystick())) {
+  if (currentBehavior && currentBehavior->redirect_joystick()) {
     cmd_vel_pub.publish(joy_vel);
   }
 }

--- a/src/mower_simulation/src/SimRobot.cpp
+++ b/src/mower_simulation/src/SimRobot.cpp
@@ -33,6 +33,7 @@ void SimRobot::Start() {
   pose_service_ = nh_.advertiseService("/xbot_positioning/set_robot_pose", &SimRobot::OnSetPose, this);
   odometry_pub_ = nh_.advertise<nav_msgs::Odometry>("odom_out", 50);
   xbot_absolute_pose_pub_ = nh_.advertise<xbot_msgs::AbsolutePose>("xb_pose_out", 50);
+  joy_vel_sub_ = nh_.subscribe("/joy_vel", 1, &SimRobot::OnJoyVel, this, ros::TransportHints().tcpNoDelay(true));
   // Keep in sync with DiffDriveService::tick_schedule_
   timer_ = nh_.createTimer(ros::Duration(0.02), &SimRobot::SimulationStep, this);
   timer_.start();
@@ -118,13 +119,35 @@ SimRobot::SimControlState SimRobot::GetSimControlState() {
   state.battery_percentage =
       std::max(0.0, std::min(1.0, (battery_volts_ - BATTERY_VOLTS_MIN) / (BATTERY_VOLTS_MAX - BATTERY_VOLTS_MIN)));
   state.charging = is_charging_;
+  state.joy_override = joy_override_;
   return state;
 }
 
 void SimRobot::SetControlTwist(double linear, double angular) {
   std::lock_guard<std::mutex> lk{state_mutex_};
+  if (joy_override_) {
+    return;
+  }
   vx_ = linear;
   vr_ = angular;
+}
+
+void SimRobot::SetJoyOverride(bool enabled) {
+  std::lock_guard<std::mutex> lk{state_mutex_};
+  joy_override_ = enabled;
+  if (!enabled) {
+    vx_ = 0.0;
+    vr_ = 0.0;
+  }
+}
+
+void SimRobot::OnJoyVel(const geometry_msgs::Twist::ConstPtr& msg) {
+  std::lock_guard<std::mutex> lk{state_mutex_};
+  if (!joy_override_) {
+    return;
+  }
+  vx_ = msg->linear.x;
+  vr_ = msg->angular.z;
 }
 
 void SimRobot::Displace(double dx, double dy, double dheading) {

--- a/src/mower_simulation/src/SimRobot.h
+++ b/src/mower_simulation/src/SimRobot.h
@@ -5,6 +5,7 @@
 #ifndef SIMROBOT_H
 #define SIMROBOT_H
 
+#include <geometry_msgs/Twist.h>
 #include <nav_msgs/Odometry.h>
 #include <ros/ros.h>
 #include <xbot_positioning/GPSControlSrv.h>
@@ -55,6 +56,9 @@ class SimRobot {
   // is still reported on the wheel odometry / gyro (wheels keep turning) but the
   // ground-truth position no longer integrates, so GPS reports no movement.
   void SetMovementAllowed(bool allowed);
+  // When joy override is enabled, /joy_vel commands drive the robot directly and all
+  // SetControlTwist() calls from the normal mower stack are ignored.
+  void SetJoyOverride(bool enabled);
   // Good GPS = RTK fix, ~2 cm accuracy. Bad GPS = no RTK fix, ~1 m accuracy.
   void SetGpsGood(bool good);
   bool IsGpsGood();
@@ -75,6 +79,7 @@ class SimRobot {
     double battery_voltage;
     double battery_percentage;
     bool charging;
+    bool joy_override;
   };
   SimControlState GetSimControlState();
 
@@ -109,6 +114,11 @@ class SimRobot {
   // When false, the ground-truth position is frozen while the reported wheel odometry
   // still follows the commanded twist -> simulates a stuck robot.
   bool movement_allowed_ = true;
+
+  // When true, /joy_vel drives the robot and SetControlTwist() calls are ignored.
+  bool joy_override_ = false;
+
+  void OnJoyVel(const geometry_msgs::Twist::ConstPtr& msg);
 
   // Last noisy twist values (for encoder/IMU readback)
   double last_noisy_vx_ = 0;
@@ -153,6 +163,7 @@ class SimRobot {
   ros::ServiceServer pose_service_;
   ros::Publisher odometry_pub_{};
   ros::Publisher xbot_absolute_pose_pub_{};
+  ros::Subscriber joy_vel_sub_{};
   // GPS quality: true = RTK fix (~2 cm), false = no RTK fix (~1 m).
   bool gps_good_ = true;
 };

--- a/src/mower_simulation/src/SimRpc.cpp
+++ b/src/mower_simulation/src/SimRpc.cpp
@@ -57,6 +57,7 @@ json toJson(const SimRobot::SimControlState& s) {
   state["battery_voltage"] = s.battery_voltage;
   state["battery_percentage"] = s.battery_percentage;
   state["charging"] = s.charging;
+  state["joy_override"] = s.joy_override;
   return state;
 }
 
@@ -121,6 +122,15 @@ void SimRpc::Start() {
     PublishState();
     return nullptr;
   });
+
+  // Enable / disable joystick override. When enabled, /joy_vel drives the robot directly
+  // and all twist commands from the normal mower stack are ignored.
+  rpc_provider_.addMethod("sim.joy_override.set",
+                          [this](const std::string&, const nlohmann::basic_json<>& params) -> json {
+                            robot_.SetJoyOverride(requireBool(params, "enabled"));
+                            PublishState();
+                            return nullptr;
+                          });
 
   // Read the current simulation control state on demand.
   rpc_provider_.addMethod("sim.state.get", [this](const std::string&, const nlohmann::basic_json<>&) -> json {

--- a/src/open_mower/params/simulation_params.yaml
+++ b/src/open_mower/params/simulation_params.yaml
@@ -8,4 +8,3 @@ mower_logic:
   gps_wait_time: 2.0
   docking_approach_distance: 1.0
   undock_distance: 1.0
-  always_allow_joystick: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added joystick override support in simulation, letting joystick input take direct control when enabled.
  * Exposed the override state in simulation status so it’s visible to control tools.

* **Bug Fixes**
  * Removed the always-on joystick allowance from mower control, so joystick input now follows the active behavior’s redirect setting.
  * Cleaned up default simulation and mower settings to match the new joystick control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->