### PR TITLE
Stop mower when enabling sim manual drive

### DIFF
--- a/src/mower_simulation/src/SimRobot.cpp
+++ b/src/mower_simulation/src/SimRobot.cpp
@@ -135,10 +135,8 @@ void SimRobot::SetControlTwist(double linear, double angular) {
 void SimRobot::SetJoyOverride(bool enabled) {
   std::lock_guard<std::mutex> lk{state_mutex_};
   joy_override_ = enabled;
-  if (!enabled) {
-    vx_ = 0.0;
-    vr_ = 0.0;
-  }
+  vx_ = 0.0;
+  vr_ = 0.0;
 }
 
 void SimRobot::OnJoyVel(const geometry_msgs::Twist::ConstPtr& msg) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Joystick override now resets robot motion commands consistently whenever the override setting is changed, preventing stale velocity values from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->