### PR TITLE
Improve perimeter docking

### DIFF
--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -114,8 +114,10 @@ Behavior* IdleBehavior::execute() {
     const bool currently_docked = last_charge_v > 5.0;
     if (currently_docked) {
       if (!pose_synced_to_dock) {
-        ROS_INFO_STREAM("Currently inside the docking station, we set the robot's pose to the docks pose.");
-        setRobotPose(docking_pose_stamped.pose);
+        if (!PerimeterUndockingBehavior::configured(config)) {
+          ROS_INFO_STREAM("Currently inside the docking station, we set the robot's pose to the docks pose.");
+          setRobotPose(docking_pose_stamped.pose);
+        }
         pose_synced_to_dock = true;
       }
     } else {

--- a/src/mower_logic/src/mower_logic/behaviors/PerimeterDocking.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/PerimeterDocking.cpp
@@ -232,6 +232,7 @@ Behavior* PerimeterDockingBehavior::arrived() {
     chargeSeen++;
     if (chargeSeen >= 2) {
       chargeSeen = 0;
+      ROS_INFO("Reached docking station after travelling %.f meters", travelled);
       return &IdleBehavior::DOCKED_INSTANCE;
     }
   } else {
@@ -267,21 +268,21 @@ Behavior* PerimeterFollowBehavior::execute() {
       continue;
     }
     /* Turn into direction of perimeter */
-    if (innerSignal() < 0) {
-      /* Inner coil is outside */
-      vel.linear.x = 0;
-      vel.angular.z = ANGULAR_SPEED * direction;
-      if (state != FOLLOW_STATE_TURN_IN) {
-        tries = 240;
-        state = FOLLOW_STATE_TURN_IN;
-      }
-    } else if (outerSignal() > 0) {
+    if (outerSignal() > 0) {
       /* Outer coil is inside */
       vel.linear.x = 0;
       vel.angular.z = -ANGULAR_SPEED * direction;
       if (state != FOLLOW_STATE_TURN_OUT) {
         tries = 240;
         state = FOLLOW_STATE_TURN_OUT;
+      }
+    } else if (innerSignal() < 0) {
+      /* Inner coil is outside */
+      vel.linear.x=0;
+      vel.angular.z=ANGULAR_SPEED*direction;
+      if (state!=FOLLOW_STATE_TURN_IN) {
+        tries=240;
+        state=FOLLOW_STATE_TURN_IN;
       }
     } else {
       vel.linear.x = SEARCH_SPEED;

--- a/src/mower_logic/src/mower_logic/behaviors/PerimeterDocking.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/PerimeterDocking.cpp
@@ -278,11 +278,11 @@ Behavior* PerimeterFollowBehavior::execute() {
       }
     } else if (innerSignal() < 0) {
       /* Inner coil is outside */
-      vel.linear.x=0;
-      vel.angular.z=ANGULAR_SPEED*direction;
-      if (state!=FOLLOW_STATE_TURN_IN) {
-        tries=240;
-        state=FOLLOW_STATE_TURN_IN;
+      vel.linear.x = 0;
+      vel.angular.z = ANGULAR_SPEED * direction;
+      if (state != FOLLOW_STATE_TURN_IN) {
+        tries = 240;
+        state = FOLLOW_STATE_TURN_IN;
       }
     } else {
       vel.linear.x = SEARCH_SPEED;


### PR DESCRIPTION
The most important change is to inhibit IdleBehavior to overwrite the real pose of the robot.

The second change is a minor optimization in the turning instructions during perimeter docking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved docking behavior by making initial pose synchronization conditional when perimeter-based undocking is configured.
  * Refined perimeter signal handling during docking so coil positioning is evaluated in a more reliable order, improving navigation around the docking station.
  * Added clearer status information when the mower reaches the docking station after traveling the configured distance threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->