### PR TITLE
Ignore RPC methods starting with `ext.`

### DIFF
--- a/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
+++ b/src/lib/xbot_monitoring/src/xbot_monitoring.cpp
@@ -776,8 +776,8 @@ void rpc_request_callback(const std::string &payload) {
 
     // Check if the method is registered
     const std::string method = req["method"];
-    if (method.compare(0, 5, "meta.") == 0) {
-      // Silently ignore methods that are handled by the meta service.
+    if (method.compare(0, 5, "meta.") == 0 || method.compare(0, 4, "ext.") == 0) {
+      // Silently ignore methods that are handled by other services.
       return;
     }
     bool is_registered = false;


### PR DESCRIPTION
I'm currently doing some experiments which involve an external service also communicating via RPC with the app. To avoid "method not found" errors, let's reserve the `ext.` prefix for such things, with methods like `ext.service1.mymethod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RPC handling to silently ignore methods prefixed with `ext.`, matching the existing behavior for `meta.` methods.
  * Prevented these methods from being forwarded for further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->