### PR TITLE
Add mower motor spinup validation before mowing

### DIFF
--- a/src/mower_comms_v1/src/mower_comms.cpp
+++ b/src/mower_comms_v1/src/mower_comms.cpp
@@ -434,14 +434,14 @@ bool setMowEnabled(mower_msgs::MowerControlSrvRequest& req, mower_msgs::MowerCon
 }
 
 bool setEmergencyStop(mower_msgs::EmergencyStopSrvRequest& req, mower_msgs::EmergencyStopSrvResponse& res) {
-  if (req.emergency) {
-    ROS_ERROR_STREAM("Setting emergency!!");
+  if (req.reason) {
+    ROS_ERROR_STREAM("Setting emergency with reason: " << req.reason);
     ll_clear_emergency = false;
   } else {
     ll_clear_emergency = true;
   }
   // Set the high level emergency instantly. Low level value will be set on next update.
-  emergency_high_level = req.emergency;
+  emergency_high_level = req.reason != 0;
   publishActuators();
   return true;
 }

--- a/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
+++ b/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
@@ -11,14 +11,10 @@ bool EmergencyServiceInterface::SetHighLevelEmergency(uint16_t reason) {
 
   if (reason != 0) {
     SendHighLevelEmergencyHelper(reason);
-
-    // Update cached state for immediate feedback.
-    latest_emergency_reason_ |= high_level_emergency_reason_;
-    PublishEmergencyState();
+    OnEmergencyReasonChanged(latest_emergency_reason_ |= high_level_emergency_reason_);
   } else {
-    // Clear all previously set high-level emergency bits.
-    SendHighLevelEmergencyHelper(0, high_level_emergency_reason_);
-    high_level_emergency_reason_ = 0;
+    SendHighLevelEmergencyHelper(
+        0, EmergencyReason::HIGH_LEVEL | EmergencyReason::MOWER_RPM_TIMEOUT | EmergencyReason::LATCH);
   }
 
   return true;

--- a/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
+++ b/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
@@ -16,8 +16,9 @@ bool EmergencyServiceInterface::SetHighLevelEmergency(uint16_t reason) {
     latest_emergency_reason_ |= high_level_emergency_reason_;
     PublishEmergencyState();
   } else {
-    // TODO: Add a separate service call to clear the latch.
-    SendHighLevelEmergencyHelper(0, EmergencyReason::HIGH_LEVEL | EmergencyReason::LATCH);
+    // Clear all previously set high-level emergency bits.
+    SendHighLevelEmergencyHelper(0, high_level_emergency_reason_);
+    high_level_emergency_reason_ = 0;
   }
 
   return true;

--- a/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
+++ b/src/mower_comms_v2/src/EmergencyServiceInterface.cpp
@@ -2,12 +2,15 @@
 
 #include <mower_msgs/Emergency.h>
 
-bool EmergencyServiceInterface::SetHighLevelEmergency(bool new_value) {
-  high_level_emergency_reason_ = new_value ? EmergencyReason::HIGH_LEVEL | EmergencyReason::LATCH : 0;
+bool EmergencyServiceInterface::SetHighLevelEmergency(uint16_t reason) {
+  // reason == 0 means clear the emergency. Otherwise latch the given reason(s).
+  if (reason != 0) {
+    reason |= EmergencyReason::HIGH_LEVEL | EmergencyReason::LATCH;
+  }
+  high_level_emergency_reason_ = reason;
 
-  // Send the new emergency state to the service.
-  if (new_value) {
-    SendHighLevelEmergencyHelper(high_level_emergency_reason_);
+  if (reason != 0) {
+    SendHighLevelEmergencyHelper(reason);
 
     // Update cached state for immediate feedback.
     latest_emergency_reason_ |= high_level_emergency_reason_;
@@ -59,6 +62,8 @@ static std::string ReasonToString(uint16_t reason) {
   CHECK_REASON(TIMEOUT_HIGH_LEVEL)
   CHECK_REASON(HIGH_LEVEL)
   CHECK_REASON(SERVICE_NOT_READY)
+  CHECK_REASON(MOWER_RPM_TIMEOUT)
+  CHECK_REASON(MOWER_RPM_LIMIT)
   return str.str();
 }
 

--- a/src/mower_comms_v2/src/EmergencyServiceInterface.h
+++ b/src/mower_comms_v2/src/EmergencyServiceInterface.h
@@ -11,7 +11,7 @@ class EmergencyServiceInterface : public EmergencyServiceInterfaceBase {
       : EmergencyServiceInterfaceBase(service_id, ctx), publisher_(publisher) {
   }
 
-  bool SetHighLevelEmergency(bool new_value);
+  bool SetHighLevelEmergency(uint16_t reason);
   void Heartbeat();
 
  protected:

--- a/src/mower_comms_v2/src/mower_comms.cpp
+++ b/src/mower_comms_v2/src/mower_comms.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<HighLevelServiceInterface> high_level_service = nullptr;
 xbot::serviceif::Context ctx{};
 
 bool setEmergencyStop(mower_msgs::EmergencyStopSrvRequest& req, mower_msgs::EmergencyStopSrvResponse& res) {
-  emergency_service->SetHighLevelEmergency(req.emergency);
+  emergency_service->SetHighLevelEmergency(req.reason);
   return true;
 }
 

--- a/src/mower_logic/CMakeLists.txt
+++ b/src/mower_logic/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
         dynamic_reconfigure
         ftc_local_planner
         mbf_msgs
+        mower_comms_v2
         mower_map
         mower_msgs
         nav_msgs
@@ -139,6 +140,9 @@ include_directories(
         ${catkin_INCLUDE_DIRS}
         ${CRYPTOPP_INCLUDE_DIRS}
         ${xbot_mqtt_INCLUDE_DIRS}
+        ${CMAKE_BINARY_DIR}/mower_comms_v2/generated/include
+        ${CMAKE_SOURCE_DIR}/lib/xbot_framework/include
+        ${CMAKE_SOURCE_DIR}/lib/xbot_framework/libxbot-service-interface/include
 )
 
 ## Declare a C++ library

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -44,5 +44,7 @@ gen.add("emergency_lift_period", int_t, 0, "Period (ms) for multiple wheels/hall
 gen.add("emergency_tilt_period", int_t, 0, "Period (ms) for a single wheel/hall to be lifted/triggered in order to count as emergency. This is to filter uneven ground", -1)
 gen.add("emergency_input_config", str_t, 0, "Comma separated list of emergency inputs (halls or stop), where each sensor can be configured in one of the following modes '[!]<I>gnore|<U>nused|<S>top|<L>Lift'", "")
 gen.add("shutdown_esc_max_pitch", int_t, 0, "Maximum pitch angle (deg) where ESC shutdown is permitted (0 to disable ESC shutdown)", 0, 0, 180)
+gen.add("mower_spinup_rpm", int_t, 0, "Minimum RPM the mower motor must reach before mowing starts. Set to 0 to disable", 2500, 0, 50000)
+gen.add("mower_spinup_timeout", double_t, 0, "Maximum time (s) to wait for mower motor to reach the target RPM", 10.0, 1.0, 60.0)
 
 exit(gen.generate("mower_logic", "mower_logic", "MowerLogic"))

--- a/src/mower_logic/cfg/MowerLogic.cfg
+++ b/src/mower_logic/cfg/MowerLogic.cfg
@@ -44,7 +44,7 @@ gen.add("emergency_lift_period", int_t, 0, "Period (ms) for multiple wheels/hall
 gen.add("emergency_tilt_period", int_t, 0, "Period (ms) for a single wheel/hall to be lifted/triggered in order to count as emergency. This is to filter uneven ground", -1)
 gen.add("emergency_input_config", str_t, 0, "Comma separated list of emergency inputs (halls or stop), where each sensor can be configured in one of the following modes '[!]<I>gnore|<U>nused|<S>top|<L>Lift'", "")
 gen.add("shutdown_esc_max_pitch", int_t, 0, "Maximum pitch angle (deg) where ESC shutdown is permitted (0 to disable ESC shutdown)", 0, 0, 180)
-gen.add("mower_spinup_rpm", int_t, 0, "Minimum RPM the mower motor must reach before mowing starts. Set to 0 to disable", 2500, 0, 50000)
+gen.add("mower_spinup_rpm", int_t, 0, "Minimum RPM the mower motor must reach before mowing starts. Set to 0 to disable", 2000, 0, 50000)
 gen.add("mower_spinup_timeout", double_t, 0, "Maximum time (s) to wait for mower motor to reach the target RPM", 10.0, 1.0, 60.0)
 
 exit(gen.generate("mower_logic", "mower_logic", "MowerLogic"))

--- a/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/IdleBehavior.cpp
@@ -23,7 +23,6 @@
 
 extern void stopMoving();
 extern void stopBlade();
-extern void setEmergencyMode(bool emergency);
 extern void setGPS(bool enabled);
 extern void setRobotPose(geometry_msgs::Pose& pose);
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -22,6 +22,7 @@
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 
+#include <EmergencyServiceInterfaceBase.hpp>
 #include <cmath>
 
 #include "../StateSubscriber.h"
@@ -44,7 +45,7 @@ extern mower_logic::MowerLogicConfig getConfig();
 extern void setConfig(mower_logic::MowerLogicConfig);
 
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
-extern void setEmergencyMode(bool emergency);
+extern void setEmergencyMode(uint16_t reason);
 
 extern StateSubscriber<mower_msgs::Status> status_state_subscriber;
 
@@ -342,7 +343,7 @@ bool MowingBehavior::wait_for_mower_spinup() {
                                                                             << "s. Entering emergency.");
       publishMowerEvent("MOW_MOTOR_SPINUP_FAILED");
       mowerEnabled = false;
-      setEmergencyMode(true);
+      setEmergencyMode(EmergencyReason::MOWER_RPM_TIMEOUT);
       return false;
     }
     check_rate.sleep();

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -44,6 +44,7 @@ extern mower_logic::MowerLogicConfig getConfig();
 extern void setConfig(mower_logic::MowerLogicConfig);
 
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
+extern void setEmergencyMode(bool emergency);
 
 extern StateSubscriber<mower_msgs::Status> status_state_subscriber;
 
@@ -336,11 +337,12 @@ bool MowingBehavior::wait_for_mower_spinup() {
       return true;
     }
     if (ros::Time::now() - spinup_start > ros::Duration(config.mower_spinup_timeout)) {
-      ROS_ERROR_STREAM("MowingBehavior: (MOW) Mower motor failed to reach "
-                       << config.mower_spinup_rpm << " RPM within " << config.mower_spinup_timeout << "s. Aborting.");
+      ROS_ERROR_STREAM("MowingBehavior: (MOW) Mower motor failed to reach " << config.mower_spinup_rpm << " RPM within "
+                                                                            << config.mower_spinup_timeout
+                                                                            << "s. Entering emergency.");
       publishMowerEvent("MOW_MOTOR_SPINUP_FAILED");
       mowerEnabled = false;
-      this->abort();
+      setEmergencyMode(true);
       return false;
     }
     check_rate.sleep();

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -332,7 +332,7 @@ bool MowingBehavior::wait_for_mower_spinup() {
       return false;
     }
     auto last_status = status_state_subscriber.getMessage();
-    if (last_status.mower_motor_rpm >= config.mower_spinup_rpm) {
+    if (std::abs(last_status.mower_motor_rpm) >= config.mower_spinup_rpm) {
       ROS_INFO_STREAM("MowingBehavior: (MOW) Mower motor reached " << last_status.mower_motor_rpm << " RPM after "
                                                                    << (ros::Time::now() - spinup_start).toSec() << "s");
       return true;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -24,10 +24,12 @@
 
 #include <cmath>
 
+#include "../StateSubscriber.h"
 #include "mower_logic/CheckPoint.h"
 #include "mower_map/ClearNavPointSrv.h"
 #include "mower_map/GetMowingAreaSrv.h"
 #include "mower_map/SetNavPointSrv.h"
+#include "mower_msgs/Status.h"
 
 extern ros::ServiceClient mapClient;
 extern ros::ServiceClient pathClient;
@@ -42,6 +44,8 @@ extern mower_logic::MowerLogicConfig getConfig();
 extern void setConfig(mower_logic::MowerLogicConfig);
 
 extern void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions);
+
+extern StateSubscriber<mower_msgs::Status> status_state_subscriber;
 
 extern std::string current_job_id;
 extern bool current_job_finished;
@@ -311,6 +315,39 @@ std::vector<std::string> getConfiguredRecoveryBehaviors() {
 }
 }  // namespace
 
+/// @return true if spinup succeeded or spinup is disabled, false if we should abort/exit
+bool MowingBehavior::wait_for_mower_spinup() {
+  if (config.mower_spinup_rpm <= 0) {
+    return true;  // spinup check disabled
+  }
+
+  ROS_INFO_STREAM("MowingBehavior: (MOW) Waiting for mower motor to reach " << config.mower_spinup_rpm
+                                                                            << " RPM before driving");
+  ros::Time spinup_start = ros::Time::now();
+  ros::Rate check_rate(10);
+  while (ros::ok()) {
+    if (aborted || requested_pause_flag || skip_area || skip_path) {
+      return false;
+    }
+    auto last_status = status_state_subscriber.getMessage();
+    if (last_status.mower_motor_rpm >= config.mower_spinup_rpm) {
+      ROS_INFO_STREAM("MowingBehavior: (MOW) Mower motor reached " << last_status.mower_motor_rpm << " RPM after "
+                                                                   << (ros::Time::now() - spinup_start).toSec() << "s");
+      return true;
+    }
+    if (ros::Time::now() - spinup_start > ros::Duration(config.mower_spinup_timeout)) {
+      ROS_ERROR_STREAM("MowingBehavior: (MOW) Mower motor failed to reach "
+                       << config.mower_spinup_rpm << " RPM within " << config.mower_spinup_timeout << "s. Aborting.");
+      publishMowerEvent("MOW_MOTOR_SPINUP_FAILED");
+      mowerEnabled = false;
+      this->abort();
+      return false;
+    }
+    check_rate.sleep();
+  }
+  return false;
+}
+
 bool MowingBehavior::execute_mowing_plan() {
   int first_point_attempt_counter = 0;
   int first_point_trim_counter = 0;
@@ -493,7 +530,13 @@ bool MowingBehavior::execute_mowing_plan() {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     {
       // enable mower (only when we reach the start not on the way to mowing already)
+      bool mower_enabled_last = mowerEnabled;
       mowerEnabled = true;
+
+      // Wait for mower motor to spin up to target RPM (if configured and previously disabled)
+      if (!mower_enabled_last && !wait_for_mower_spinup()) {
+        return false;
+      }
 
       mbf_msgs::ExePathGoal exePathGoal;
       nav_msgs::Path exePath;

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.h
@@ -32,6 +32,9 @@ class MowingBehavior : public Behavior {
 
   bool execute_mowing_plan();
 
+  /// @return true if spinup succeeded or spinup is disabled, false if we should abort/exit
+  bool wait_for_mower_spinup();
+
   // Progress
   bool mowerEnabled = false;
   std::vector<slic3r_coverage_planner::Path> currentMowingPaths;

--- a/src/mower_logic/src/mower_logic/mower_logic.cpp
+++ b/src/mower_logic/src/mower_logic/mower_logic.cpp
@@ -24,6 +24,7 @@
 #include <mower_msgs/Power.h>
 #include <tf2/LinearMath/Transform.h>
 
+#include <EmergencyServiceInterfaceBase.hpp>
 #include <algorithm>
 #include <atomic>
 #include <ios>
@@ -161,7 +162,7 @@ xbot_msgs::AbsolutePose getPose() {
   return pose_state_subscriber.getMessage();
 }
 
-void setEmergencyMode(bool emergency);
+void setEmergencyMode(uint16_t reason);
 
 void registerActions(std::string prefix, const std::vector<xbot_msgs::ActionInfo>& actions) {
   xbot_msgs::RegisterActionsSrv srv;
@@ -203,7 +204,7 @@ void setRobotPose(geometry_msgs::Pose& pose) {
 
   if (!success) {
     ROS_ERROR_STREAM("Error setting robot pose. Going to emergency. THIS SHOULD NEVER HAPPEN");
-    setEmergencyMode(true);
+    setEmergencyMode(EmergencyReason::HIGH_LEVEL);
   }
 }
 
@@ -232,7 +233,7 @@ bool setGPS(bool enabled) {
 
   if (!success) {
     ROS_ERROR_STREAM("Error setting GPS. Going to emergency. THIS SHOULD NEVER HAPPEN");
-    setEmergencyMode(true);
+    setEmergencyMode(EmergencyReason::HIGH_LEVEL);
   }
 
   return success;
@@ -346,28 +347,28 @@ void stopBlade() {
 }
 
 /// @brief Stop BLADE motor and any movement
-/// @param emergency
-void setEmergencyMode(bool emergency) {
+/// @param reason Emergency reason bitfield (0 = clear, != 0 = emergency with given reasons)
+void setEmergencyMode(uint16_t reason) {
   stopBlade();
   stopMoving();
   mower_msgs::EmergencyStopSrv emergencyStop;
-  emergencyStop.request.emergency = emergency;
+  emergencyStop.request.reason = reason;
 
-  static bool last_emergency = false;
-  if (emergency != last_emergency) {
-    publishMowerEvent("EMERGENCY", json{{"emergency", emergency}});
-    last_emergency = emergency;
+  static uint16_t last_reason = 0;
+  if (reason != last_reason) {
+    publishMowerEvent("EMERGENCY", json{{"emergency", reason != 0}, {"reason", reason}});
+    last_reason = reason;
   }
 
   ros::Rate retry_delay(1);
   bool success = false;
   for (int i = 0; i < 10; i++) {
     if (emergencyClient.call(emergencyStop)) {
-      ROS_INFO_STREAM("successfully set emergency enabled to " << emergency);
+      ROS_INFO_STREAM("successfully set emergency reason to " << reason);
       success = true;
       break;
     }
-    ROS_ERROR_STREAM("Error setting emergency enabled to " << emergency << ". Retrying.");
+    ROS_ERROR_STREAM("Error setting emergency reason to " << reason << ". Retrying.");
     retry_delay.sleep();
   }
 
@@ -464,7 +465,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
         if (high_level_status.is_charging) {
           // emergency and docked and idle or area recording, so it's safe to reset the emergency mode, reset it. It's
           // safe since we won't start moving in this mode.
-          setEmergencyMode(false);
+          setEmergencyMode(0);
         }
       }
     } else {
@@ -486,7 +487,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   // check if status is current. if not, we have a problem since it contains wheel ticks and so on.
   // Since these should never drop out, we enter emergency instead of "only" stopping
   if (ros::Time::now() - status_time > ros::Duration(3) || ros::Time::now() - power_time > ros::Duration(3)) {
-    setEmergencyMode(true);
+    setEmergencyMode(EmergencyReason::HIGH_LEVEL);
     ROS_WARN_STREAM_THROTTLE(
         5, "om_mower_logic: EMERGENCY /mower/status values stopped. dt was: " << (ros::Time::now() - status_time));
     return;
@@ -495,7 +496,7 @@ void checkSafety(const ros::TimerEvent& timer_event) {
   // If the motor controllers error, we enter emergency mode in the hope to save them. They should not error.
   if (last_left_esc_state.status <= mower_msgs::ESCStatus::ESC_STATUS_ERROR ||
       last_right_esc_state.status <= mower_msgs::ESCStatus::ESC_STATUS_ERROR) {
-    setEmergencyMode(true);
+    setEmergencyMode(EmergencyReason::HIGH_LEVEL);
     ROS_ERROR_STREAM("EMERGENCY: at least one motor control errored. errors left: "
                      << (last_left_esc_state.status) << ", status right: " << last_right_esc_state.status);
     return;
@@ -682,7 +683,7 @@ bool highLevelCommand(mower_msgs::HighLevelControlSrvRequest& req, mower_msgs::H
     } break;
     case mower_msgs::HighLevelControlSrvRequest::COMMAND_RESET_EMERGENCY:
       ROS_WARN_STREAM("COMMAND_RESET_EMERGENCY");
-      setEmergencyMode(false);
+      setEmergencyMode(0);
       break;
   }
   return true;
@@ -691,7 +692,7 @@ bool highLevelCommand(mower_msgs::HighLevelControlSrvRequest& req, mower_msgs::H
 void actionReceived(const std_msgs::String::ConstPtr& action) {
   if (action->data == "mower_logic/reset_emergency") {
     ROS_WARN_STREAM("Got reset emergency action.");
-    setEmergencyMode(false);
+    setEmergencyMode(0);
     return;
   }
 
@@ -964,7 +965,7 @@ int main(int argc, char** argv) {
     r.sleep();
     if (emergency_state_subscriber.getMessage().latched_emergency) {
       ROS_INFO_STREAM("Got emergency, resetting it");
-      setEmergencyMode(false);
+      setEmergencyMode(0);
       break;
     }
   }
@@ -979,7 +980,7 @@ int main(int argc, char** argv) {
   ros::Timer ui_timer = n->createTimer(ros::Duration(1.0), updateUI);
 
   // release emergency if it was set
-  setEmergencyMode(false);
+  setEmergencyMode(0);
 
   // initialise the shared state object to be passed into the behaviors
   auto shared_state = std::make_shared<sSharedState>();
@@ -1021,7 +1022,7 @@ int main(int argc, char** argv) {
       high_level_state_publisher.publish(high_level_status);
       // we have no defined behavior, set emergency
       ROS_ERROR_STREAM("null behavior - emergency mode");
-      setEmergencyMode(true);
+      setEmergencyMode(EmergencyReason::HIGH_LEVEL);
       ros::Rate r(1.0);
       r.sleep();
     }

--- a/src/mower_msgs/srv/EmergencyStopSrv.srv
+++ b/src/mower_msgs/srv/EmergencyStopSrv.srv
@@ -1,2 +1,2 @@
-uint8 emergency
+uint16 reason
 ---

--- a/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
@@ -24,4 +24,6 @@ xbot_positioning:
   antenna_offset_y: 0.0
 
 mower_logic:
-  tool_width: 0.28
+  tool_width: 0.25
+  mower_spinup_rpm: 3000
+  mower_spinup_timeout: 30.0

--- a/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
+++ b/src/open_mower/params/hardware_specific/Sabo/params_v2.yaml
@@ -25,5 +25,5 @@ xbot_positioning:
 
 mower_logic:
   tool_width: 0.25
-  mower_spinup_rpm: 3000
+  mower_spinup_rpm: 2000
   mower_spinup_timeout: 30.0

--- a/src/open_mower/params/openmower_defaults_v2.yaml
+++ b/src/open_mower/params/openmower_defaults_v2.yaml
@@ -56,10 +56,11 @@ mower_logic:
   emergency_lift_period: -1
   emergency_tilt_period: -1
   ignore_charging_current: false
+  mower_spinup_rpm: 2500
+  mower_spinup_timeout: 10.0
 
 xbot_monitoring:
   external_mqtt_enable: false
-
 
 # Openmower doesn't work in m/s but duty cycle by default, so we must adjust the speed for the recovery behavior
 move_base_flex:

--- a/src/open_mower/params/openmower_defaults_v2.yaml
+++ b/src/open_mower/params/openmower_defaults_v2.yaml
@@ -56,7 +56,7 @@ mower_logic:
   emergency_lift_period: -1
   emergency_tilt_period: -1
   ignore_charging_current: false
-  mower_spinup_rpm: 2500
+  mower_spinup_rpm: 2000
   mower_spinup_timeout: 10.0
 
 xbot_monitoring:


### PR DESCRIPTION
- add `mower_spinup_rpm` and `mower_spinup_timeout` configuration parameters
- implement `wait_for_mower_spinup()` to ensure mower motor reaches target RPM before driving
- trigger emergency if spinup fails or timeout is exceeded
- add default spinup values as well as Sabo specific ones

This PR assumes mechanical RPM and not eRPM, which isn't the case ATM for V2 hardware.
See https://github.com/xtech/fw-openmower-v2/pull/77 for the eRPM-2-RPM fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable mower motor spin-up RPM and timeout settings.
  - Mowing waits for the motor to reach the configured speed before starting.
  - Setting the target RPM to zero disables spin-up checking.
  - Pausing, skipping, or aborting cancels the spin-up wait.
- **Safety**
  - Spin-up timeouts trigger emergency mode with a diagnostic reason.
  - Emergency events now preserve, report, and clear their causes consistently.
- **Configuration**
  - Added default spin-up settings for supported mower configurations.
  - Updated the Sabo mower tool width from 0.28 m to 0.25 m.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->