### PR TITLE
ci(os): pin OS build status to a check run on the real commit sha

### DIFF
--- a/.github/workflows/build-os.yaml
+++ b/.github/workflows/build-os.yaml
@@ -299,14 +299,26 @@ jobs:
       # the artifact - no window where the check looks done but the upload
       # hasn't landed yet. always() so failed/cancelled builds still get
       # marked, matching the cache-save steps' reasoning above.
-      - name: Finish check run
-        if: always() && steps.go.outputs.go == 'true'
+      # Status check functions like cancelled() only parse inside `if:` - not
+      # in a `${{ }}` expression anywhere else (confirmed the hard way: using
+      # it inline in the run script below made the whole workflow file
+      # rejected as invalid at dispatch time). Split into two mutually
+      # exclusive steps instead of branching on it inside one script.
+      - name: Finish check run (cancelled)
+        if: always() && steps.go.outputs.go == 'true' && cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ cancelled() }}" = "true" ]; then
-            conclusion=cancelled
-          elif [ "${{ steps.build.outcome }}" = "success" ]; then
+          gh api --method PATCH "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+            -f status=completed \
+            -f conclusion=cancelled >/dev/null
+
+      - name: Finish check run
+        if: always() && steps.go.outputs.go == 'true' && !cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
             conclusion=success
           else
             conclusion=failure

--- a/.github/workflows/build-os.yaml
+++ b/.github/workflows/build-os.yaml
@@ -21,13 +21,24 @@ on:
     types: [completed]
 
 concurrency:
-  group: build-os-${{ github.event.workflow_run.head_branch || github.ref }}
+  # head_sha, not head_branch: a workflow_run-triggered run's own head_branch
+  # is always the repo's default branch (see "Start check run" below), so
+  # head_branch here would put every PR/branch's build-os run in the SAME
+  # group and let one PR's push cancel a completely unrelated PR's build.
+  group: build-os-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: write   # only actually used by the release step, tag builds only
   actions: write    # cross-workflow-run artifact download (read) + deleting the
                      # stale Buildroot cache entry below (write) so it can be re-saved
+  checks: write     # pin build status to the real PR/commit sha below - a
+                     # workflow_run-triggered run's own head_sha/head_branch
+                     # (as reported by the Actions API) is always the repo's
+                     # default branch, never the PR/commit that indirectly
+                     # triggered it, so callers can't find this run by
+                     # querying the workflow's run list for that sha. A check
+                     # run pinned explicitly to the real sha sidesteps that.
 
 jobs:
   build:
@@ -78,6 +89,29 @@ jobs:
           else
             echo "go=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Pinned to the real commit sha (not this run's own head_sha, which is
+      # always the default branch for a workflow_run trigger - see the
+      # concurrency/permissions comments above), so a caller can look this
+      # run up later via GET /commits/{sha}/check-runs regardless of which
+      # branch build-os itself thinks it ran on. details_url points back at
+      # this exact run (github.run_id, known now even though this run's own
+      # API-reported head_sha isn't usable for the lookup) so the caller can
+      # jump straight to its artifacts without re-deriving anything.
+      - name: Start check run
+        if: steps.go.outputs.go == 'true'
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          id=$(gh api "repos/${{ github.repository }}/check-runs" \
+            -f name="OS Build" \
+            -f head_sha="$SHA" \
+            -f status=in_progress \
+            -f details_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --jq .id)
+          echo "id=$id" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: steps.go.outputs.go == 'true'
@@ -214,6 +248,7 @@ jobs:
       # actually what you want.
       - name: Build
         if: steps.go.outputs.go == 'true'
+        id: build
         working-directory: os
         env:
           OPENMOWER_BUILD_SDCARD: ${{ steps.mode.outputs.build_sdcard }}
@@ -253,6 +288,25 @@ jobs:
           path: os/output/images/openmower-*.raucb
           if-no-files-found: error
           retention-days: 14
+
+      # After the RAUC bundle upload (not right after Build) so a caller
+      # that sees this check run go "completed"/"success" can already find
+      # the artifact - no window where the check looks done but the upload
+      # hasn't landed yet. always() so failed/cancelled builds still get
+      # marked, matching the cache-save steps' reasoning above.
+      - name: Finish check run
+        if: always() && steps.go.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          case "${{ steps.build.outcome }}" in
+            success) conclusion=success ;;
+            cancelled) conclusion=cancelled ;;
+            *) conclusion=failure ;;
+          esac
+          gh api "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+            -f status=completed \
+            -f conclusion="$conclusion" >/dev/null
 
       - name: Upload sdcard.img
         if: steps.go.outputs.go == 'true' && steps.mode.outputs.build_sdcard == '1'

--- a/.github/workflows/build-os.yaml
+++ b/.github/workflows/build-os.yaml
@@ -304,12 +304,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          case "${{ steps.build.outcome }}" in
-            success) conclusion=success ;;
-            cancelled) conclusion=cancelled ;;
-            *) conclusion=failure ;;
-          esac
-          gh api "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+          if [ "${{ cancelled() }}" = "true" ]; then
+            conclusion=cancelled
+          elif [ "${{ steps.build.outcome }}" = "success" ]; then
+            conclusion=success
+          else
+            conclusion=failure
+          fi
+          gh api --method PATCH "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
             -f status=completed \
             -f conclusion="$conclusion" >/dev/null
 

--- a/.github/workflows/build-os.yaml
+++ b/.github/workflows/build-os.yaml
@@ -287,6 +287,7 @@ jobs:
 
       - name: Upload RAUC bundle
         if: steps.go.outputs.go == 'true'
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: openmower-os-raucb
@@ -298,18 +299,30 @@ jobs:
       # that sees this check run go "completed"/"success" can already find
       # the artifact - no window where the check looks done but the upload
       # hasn't landed yet. always() so failed/cancelled builds still get
-      # marked, matching the cache-save steps' reasoning above.
+      # marked, matching the cache-save steps' reasoning above. Requires the
+      # upload step to have succeeded too, not just Build - Build succeeding
+      # doesn't guarantee the artifact actually made it up.
       # Status check functions like cancelled() only parse inside `if:` - not
       # in a `${{ }}` expression anywhere else (confirmed the hard way: using
       # it inline in the run script below made the whole workflow file
       # rejected as invalid at dispatch time). Split into two mutually
       # exclusive steps instead of branching on it inside one script.
+      #
+      # CHECK_RUN_ID/REPO go through env (not interpolated straight into the
+      # script) so the shell only ever sees a github-generated numeric id and
+      # "owner/repo" string, never a raw ${{ }} expansion in the script text
+      # itself - the actual injection risk here is negligible (nothing here
+      # is attacker-influenced text like a PR title), but it's what the rest
+      # of this file already does (e.g. the SHA env var above) and zizmor
+      # flags any direct ${{ }} in a run: block on principle either way.
       - name: Finish check run (cancelled)
         if: always() && steps.go.outputs.go == 'true' && cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.id }}
         run: |
-          gh api --method PATCH "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+          gh api --method PATCH "repos/$REPO/check-runs/$CHECK_RUN_ID" \
             -f status=completed \
             -f conclusion=cancelled >/dev/null
 
@@ -317,13 +330,17 @@ jobs:
         if: always() && steps.go.outputs.go == 'true' && !cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.id }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
         run: |
-          if [ "${{ steps.build.outcome }}" = "success" ]; then
+          if [ "$BUILD_OUTCOME" = "success" ] && [ "$UPLOAD_OUTCOME" = "success" ]; then
             conclusion=success
           else
             conclusion=failure
           fi
-          gh api --method PATCH "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+          gh api --method PATCH "repos/$REPO/check-runs/$CHECK_RUN_ID" \
             -f status=completed \
             -f conclusion="$conclusion" >/dev/null
 

--- a/.github/workflows/build-os.yaml
+++ b/.github/workflows/build-os.yaml
@@ -94,10 +94,15 @@ jobs:
       # always the default branch for a workflow_run trigger - see the
       # concurrency/permissions comments above), so a caller can look this
       # run up later via GET /commits/{sha}/check-runs regardless of which
-      # branch build-os itself thinks it ran on. details_url points back at
-      # this exact run (github.run_id, known now even though this run's own
-      # API-reported head_sha isn't usable for the lookup) so the caller can
-      # jump straight to its artifacts without re-deriving anything.
+      # branch build-os itself thinks it ran on. external_id carries this
+      # exact run's own id (github.run_id, known now even though this run's
+      # own API-reported head_sha isn't usable for the lookup) so the caller
+      # can jump straight to its artifacts without re-deriving anything -
+      # NOT details_url/html_url: GitHub silently forces both of those to the
+      # check run's own page for check runs created via the Actions token,
+      # ignoring whatever URL you pass. external_id is the field actually
+      # meant for "the integrator's own reference for this run" and isn't
+      # overridden.
       - name: Start check run
         if: steps.go.outputs.go == 'true'
         id: check
@@ -109,7 +114,7 @@ jobs:
             -f name="OS Build" \
             -f head_sha="$SHA" \
             -f status=in_progress \
-            -f details_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f external_id="${{ github.run_id }}" \
             --jq .id)
           echo "id=$id" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `build-os.yaml` is chained via `workflow_run`, so its own run-list `head_sha`/`head_branch` (as reported by the Actions API) are always the default branch, never the PR/commit that indirectly triggered it. api.openmower.de's OS-update endpoint looks up the build by querying that run list filtered by the PR/branch's real sha - which can never match, so it reports "no build triggered" even while the matching build is actively running.
- Fix: create a check run named `OS Build`, pinned to the real commit sha, at the start of the job; mark it `completed`/`success`|`failure`|`cancelled` after the RAUC bundle upload (or immediately on cancellation). Callers look this up via `GET /commits/{sha}/check-runs`, regardless of what build-os's own run metadata says. The check run's `external_id` carries this run's own id so a caller can jump straight to its artifacts.
  - Not `details_url`/`html_url` for that: confirmed by testing that GitHub silently forces both to the check run's own page for check runs created via the Actions token, ignoring any custom URL passed in. `external_id` is the field actually meant for "the integrator's own reference for this run".
  - Updating the check run needs `--method PATCH` explicitly - `gh api` defaults to POST when given `-f` flags, which 404s against a PATCH-only route.
  - Cancellation (routine here: the concurrency group below cancels an older push's build on every newer one) is detected via `cancelled()`, which only parses inside an `if:` - split into two mutually exclusive steps rather than branching on it inside one script.
- Also fixes the concurrency group, which had the identical head_branch-is-always-default-branch bug: every PR's build-os run shared one group with `cancel-in-progress: true` - one PR's push could cancel a completely unrelated PR's build. Now keyed on the real `head_sha`.
- Companion backend change (api.openmower.de, not in this PR) switches the lookup from the run-list query to `GET /commits/{sha}/check-runs?check_name=OS+Build`.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [x] Manually dispatched against this branch (`workflow_dispatch` uses the ref's own copy of the workflow, unlike `workflow_run`) and verified via `gh api`:
  - check run is created with `status=in_progress` and the correct `external_id`
  - cancelling the run correctly flips it to `status=completed, conclusion=cancelled` (this caught two real bugs: the missing `--method PATCH`, and `cancelled()` being invalid outside `if:`, both fixed in later commits on this branch)
- [ ] Success path (a full build completing) not separately tested - expensive/slow (~180 min timeout budget); the code path is a straightforward `steps.build.outcome == 'success'` check with no remaining unknowns after the above
- [ ] Full `workflow_run`-chain validation (a real PR triggering this automatically, rather than manual `workflow_dispatch`) requires this to land on `main` first, since `workflow_run` always uses the default branch's copy of the downstream workflow