### PR TITLE
test: verify OS build check-run tagging (throwaway, will close not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ Copy the settings for **Build directory** and **CMake options**. Everything else
 # License
 
 This work is licensed under the [GNU General Public License version 3](https://www.gnu.org/licenses/gpl-3.0.html). See the [LICENSE](LICENSE) file for details.
+<!-- test: verifying OS build check-run tagging after #338, throwaway PR -->


### PR DESCRIPTION
Throwaway PR to verify #338 actually works end-to-end now that it's on `main`: a real `pull_request`-triggered "Build" run, chaining via `workflow_run` into `build-os.yaml` (now the fixed version, since `workflow_run` always uses the default branch's copy of the downstream workflow), should create/complete an `OS Build` check run pinned to this PR's real head sha.

No functional change - single HTML comment appended to README.md. Will close (not merge) once verified.