### PR TITLE
ci: send source_repo in the OS build dispatch payload

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -313,6 +313,11 @@ jobs:
           SHA: ${{ github.sha }}
           IS_RELEASE: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
+          # This repo, not OpenMower's own -- client_payload[sha] is a commit
+          # here, and OpenMower only knows that because it's the one pulling
+          # the image; without this it has no way to link back to the
+          # open_mower_ros commit that produced it.
+          SOURCE_REPO: ${{ github.repository }}
         run: |
           if [ -z "$DIGEST" ]; then
             echo "No manifest digest (manifest step skipped, e.g. a filtered workflow_dispatch run) -- nothing to dispatch"
@@ -331,4 +336,5 @@ jobs:
             -f "client_payload[sha]=$SHA" \
             -f "client_payload[image]=$IMAGE" \
             -F "client_payload[is_release]=$IS_RELEASE" \
-            -f "client_payload[tag_name]=$([ "$IS_RELEASE" = "true" ] && echo "$REF" || echo "")"
+            -f "client_payload[tag_name]=$([ "$IS_RELEASE" = "true" ] && echo "$REF" || echo "")" \
+            -f "client_payload[source_repo]=$SOURCE_REPO"

--- a/.github/workflows/push-pr-image.yaml
+++ b/.github/workflows/push-pr-image.yaml
@@ -193,6 +193,9 @@ jobs:
           PR: ${{ steps.pr.outputs.number }}
           SHA: ${{ github.event.workflow_run.head_sha }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
+          # This repo, not OpenMower's own -- see build-image.yaml's matching
+          # Trigger OS build step for why.
+          SOURCE_REPO: ${{ github.repository }}
         run: |
           if [ -z "$DIGEST" ]; then
             echo "No manifest digest (manifest step found no digests to combine) -- nothing to dispatch"
@@ -206,4 +209,5 @@ jobs:
             -f "client_payload[sha]=$SHA" \
             -f "client_payload[image]=$IMAGE" \
             -F "client_payload[is_release]=false" \
-            -f "client_payload[tag_name]="
+            -f "client_payload[tag_name]=" \
+            -f "client_payload[source_repo]=$SOURCE_REPO"


### PR DESCRIPTION
## Summary
- The `Trigger OS build` steps in `build-image.yaml` and `push-pr-image.yaml` fire a `repository_dispatch` to `ClemensElflein/OpenMower` carrying `sha` - a commit in *this* repo. OpenMower's `os-build.yaml` then reports that sha to api.openmower.de tagged with `repo: ClemensElflein/OpenMower`, so the UI links to a commit that doesn't exist there.
- Adds `client_payload[source_repo]=${{ github.repository }}` to both dispatch calls so the real source repo travels alongside the sha.

Paired with a matching OpenMower PR (forwards source_repo to api.openmower.de) and an api.openmower.de PR (records/renders it).

## Test plan
- [ ] Merge alongside the OpenMower and api.openmower.de PRs, then confirm a build/PR/tag push produces a correct commit link on api.openmower.de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OS image build notifications now include the repository that initiated the build.
  * Improved build metadata and comments for clearer source tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->