### PR TITLE
Fix IPv6 disabled for remote

### DIFF
--- a/src/lib/xbot_remote/src/xbot_remote.cpp
+++ b/src/lib/xbot_remote/src/xbot_remote.cpp
@@ -61,7 +61,22 @@ void* server_thread(void* arg) {
         echo_server.set_reuse_addr(true);
 
         // Listen on port 9002
-        echo_server.listen(9002);
+        // create error message var so we can handle errors gracefully
+        websocketpp::lib::error_code ec;
+        auto port = 9002;
+        echo_server.listen(port, ec);
+
+        if (ec) { //oh no, error
+            ROS_INFO_STREAM("Default WebSocket listen failed (" << ec.message() << "). Falling back to IPv4.");
+            ec.clear();
+            // Assume it's because IPv6 is missing, explicitly request IPv4
+            echo_server.listen(websocketpp::lib::asio::ip::tcp::v4(), port, ec);
+            // If it STILL fails, something else is wrong (e.g., port in use)
+            if (ec) {
+                ROS_FATAL_STREAM("Failed to start WebSocket server on IPv4 as well: " << ec.message());
+                throw websocketpp::exception(ec);
+            }
+        }
 
         // Start the server accept loop
         echo_server.start_accept();


### PR DESCRIPTION
Fixes the a crash in `xbox_remote`  when IPv6 is removed from the kernel, rather than disabled (thanks ecovacs!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket server startup reliability.
  * Added a fallback to IPv4 when the default connection attempt fails.
  * Added clearer handling for startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->