### PR TITLE
fix(params): add v1 board default

### DIFF
--- a/src/open_mower/launch/include/_params.launch
+++ b/src/open_mower/launch/include/_params.launch
@@ -15,6 +15,7 @@
         <group unless="$(eval env('MOWER')=='CUSTOM')">
             <!-- v1 comms parameters for v1 platform (serial ports etc), we don't need it for v2 -->
 	    <group if="$(eval env('HARDWARE_PLATFORM') == '1')">
+	        <rosparam file="$(find open_mower)/params/openmower_defaults_v1.yaml"/>
 	        <rosparam ns="ll"
                   file="$(find open_mower)/params/hardware_specific/$(env MOWER)/comms_general_params.yaml"/>
 	        <rosparam ns="ll/services/diff_drive"
@@ -33,6 +34,7 @@
 
     <group if="$(optenv OM_LEGACY_CONFIG_MODE False)">
         <!-- V1 hardware with v1 OS (params are stored as environment variables) -->
+        <rosparam file="$(find open_mower)/params/openmower_defaults_v1.yaml"/>
         <!-- mower_comms -->
         <rosparam unless="$(eval env('MOWER')=='CUSTOM')"
                   ns="ll"

--- a/src/open_mower/params/openmower_defaults_v1.yaml
+++ b/src/open_mower/params/openmower_defaults_v1.yaml
@@ -1,0 +1,2 @@
+ll:
+  board: "YardForce-V1"


### PR DESCRIPTION
## Summary
- add a YardForce-V1 board default for v1 hardware
- load the default in both OS-v2 and legacy v1 parameter paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default configuration loading for supported mower hardware platforms.
  * Added the YardForce-V1 board as the default board in the legacy configuration.
  * Ensured both current and legacy configurations apply the appropriate defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->