### PR TITLE
fix(mower_logic): catch BagUnindexedException in checkpoint restore

### DIFF
--- a/src/mower_logic/package.xml
+++ b/src/mower_logic/package.xml
@@ -15,6 +15,7 @@
   <build_depend>mower_map</build_depend>
   <build_depend>mower_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>rosbag</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>slic3r_coverage_planner</build_depend>
   <build_depend>tf2</build_depend>
@@ -33,6 +34,7 @@
   <build_export_depend>mower_map</build_export_depend>
   <build_export_depend>mower_msgs</build_export_depend>
   <build_export_depend>nav_msgs</build_export_depend>
+  <build_export_depend>rosbag</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>slic3r_coverage_planner</build_export_depend>
   <build_export_depend>tf2</build_export_depend>
@@ -46,6 +48,7 @@
   <exec_depend>mower_map</exec_depend>
   <exec_depend>mower_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>rosbag</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>slic3r_coverage_planner</exec_depend>
   <exec_depend>tf2</exec_depend>

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -832,6 +832,28 @@ bool MowingBehavior::restore_checkpoint() {
   bool found = false;
   try {
     bag.open("checkpoint.bag");
+    {
+      rosbag::View view(bag, rosbag::TopicQuery("checkpoint"));
+      for (rosbag::MessageInstance const m : view) {
+        auto cp = m.instantiate<mower_logic::CheckPoint>();
+        if (cp) {
+          ROS_INFO_STREAM("Restoring checkpoint for plan ("
+                          << cp->currentMowingPlanDigest << ")"
+                          << " job: " << cp->job_id << " area: " << cp->currentMowingArea
+                          << " path: " << cp->currentMowingPath << " index: " << cp->currentMowingPathIndex
+                          << " angle increment sum: " << cp->currentMowingAngleIncrementSum);
+          current_job_id = cp->job_id;
+          currentMowingPath = cp->currentMowingPath;
+          currentMowingArea = cp->currentMowingArea;
+          currentMowingPathIndex = cp->currentMowingPathIndex;
+          currentMowingPlanDigest = cp->currentMowingPlanDigest;
+          currentMowingAngleIncrementSum = cp->currentMowingAngleIncrementSum;
+          found = true;
+          break;
+        }
+      }
+      bag.close();
+    }
   } catch (rosbag::BagIOException& e) {
     // Checkpoint does not exist or is corrupt, start at the very beginning
     currentMowingArea = 0;
@@ -839,28 +861,13 @@ bool MowingBehavior::restore_checkpoint() {
     currentMowingPathIndex = 0;
     currentMowingAngleIncrementSum = 0;
     return false;
-  }
-  {
-    rosbag::View view(bag, rosbag::TopicQuery("checkpoint"));
-    for (rosbag::MessageInstance const m : view) {
-      auto cp = m.instantiate<mower_logic::CheckPoint>();
-      if (cp) {
-        ROS_INFO_STREAM("Restoring checkpoint for plan ("
-                        << cp->currentMowingPlanDigest << ")"
-                        << " job: " << cp->job_id << " area: " << cp->currentMowingArea
-                        << " path: " << cp->currentMowingPath << " index: " << cp->currentMowingPathIndex
-                        << " angle increment sum: " << cp->currentMowingAngleIncrementSum);
-        current_job_id = cp->job_id;
-        currentMowingPath = cp->currentMowingPath;
-        currentMowingArea = cp->currentMowingArea;
-        currentMowingPathIndex = cp->currentMowingPathIndex;
-        currentMowingPlanDigest = cp->currentMowingPlanDigest;
-        currentMowingAngleIncrementSum = cp->currentMowingAngleIncrementSum;
-        found = true;
-        break;
-      }
-    }
-    bag.close();
+  } catch (rosbag::BagUnindexedException& e) {
+    // Bag file corrupted/unindexed (app crash during write), reset state
+    currentMowingArea = 0;
+    currentMowingPath = 0;
+    currentMowingPathIndex = 0;
+    currentMowingAngleIncrementSum = 0;
+    return false;
   }
   return found;
 }

--- a/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
+++ b/src/mower_logic/src/mower_logic/behaviors/MowingBehavior.cpp
@@ -868,6 +868,13 @@ bool MowingBehavior::restore_checkpoint() {
     currentMowingPathIndex = 0;
     currentMowingAngleIncrementSum = 0;
     return false;
+  } catch (rosbag::BagFormatException& e) {
+    // Bag file has invalid format, reset state
+    currentMowingArea = 0;
+    currentMowingPath = 0;
+    currentMowingPathIndex = 0;
+    currentMowingAngleIncrementSum = 0;
+    return false;
   }
   return found;
 }


### PR DESCRIPTION
Handle corrupted or unindexed rosbag checkpoint files gracefully instead of crashing.

- Catch `rosbag::BagUnindexedException` in `restore_checkpoint()` alongside `rosbag::BagIOException`
- Both exceptions reset mowing state to initial values and return false
- Expanded try-catch scope to cover the entire bag file access (open, view, iterate)
- Added explicit rosbag dependency to package.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when restoring mowing checkpoints from corrupted, unindexed, or invalid-format data.
  * Mowing progress and angle settings are now reset when checkpoint restoration fails.
  * Restoration failures are reported more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->