### PR TITLE
Enhance Docker build process to support software versioning via build arguments

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -83,6 +83,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          # Full history + tags so `git describe` can resolve the real version below.
+          fetch-depth: 0
+
+      # Compute the software version here (git is available in the runner, but the
+      # Docker build context excludes .git/, so the container can't compute it itself).
+      - name: Compute version
+        id: version
+        run: |
+          version=$(git describe --tags 2>/dev/null || git describe --always 2>/dev/null || echo v0.0.0)
+          echo "version=${version}" >> ${GITHUB_OUTPUT}
+          echo "Software version: ${version}"
 
       # Setup Python 3
       - name: Set up Python
@@ -144,6 +155,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.docker_build_arch }}
+          build-args: |
+            OM_SOFTWARE_VERSION=${{ steps.version.outputs.version }}
           no-cache: ${{ inputs.clean_build == true || false }}
           labels: ${{ env.META_LABELS }}
           outputs: type=image,name=ghcr.io/${{ env.REPOSITORY_LC }},push-by-digest=true,name-canonical=true,push=true
@@ -157,6 +170,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.docker_build_arch }}
+          build-args: |
+            OM_SOFTWARE_VERSION=${{ steps.version.outputs.version }}
           tags: open_mower-pr:${{ matrix.variant }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.variant }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -85,6 +85,7 @@ jobs:
           submodules: 'recursive'
           # Full history + tags so `git describe` can resolve the real version below.
           fetch-depth: 0
+          persist-credentials: false
 
       # Compute the software version here (git is available in the runner, but the
       # Docker build context excludes .git/, so the container can't compute it itself).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,11 @@ WORKDIR /opt/open_mower_ros
 
 RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
-RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo \"v0.0.0\")" > version_info.env
+# Version is passed as a build-arg from CI (the build context excludes .git/, so an
+# in-container `git describe` can't resolve it). Fall back to git describe for local
+# builds that include .git/, then to v0.0.0.
+ARG OM_SOFTWARE_VERSION=""
+RUN echo "export OM_SOFTWARE_VERSION=${OM_SOFTWARE_VERSION:-$(git describe --tags 2>/dev/null || git describe --always 2>/dev/null || echo v0.0.0)}" > version_info.env
 
 RUN mkdir -p /config
 COPY ./docker/assets/rosconsole.config /config/rosconsole.config

--- a/docker/Dockerfile.Legacy
+++ b/docker/Dockerfile.Legacy
@@ -96,7 +96,11 @@ WORKDIR /opt/open_mower_ros
 
 RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && cd /opt/open_mower_ros/src && catkin_init_workspace && cd .. && source /opt/prebuilt/slic3r_coverage_planner/setup.bash && source /opt/prebuilt/rosserial/setup.bash --extend && catkin_make -DCATKIN_BLACKLIST_PACKAGES=slic3r_coverage_planner"
 
-RUN echo "export OM_SOFTWARE_VERSION=$(git describe --tags || git describe --always || echo "v0.0.0")" > version_info.env
+# Version is passed as a build-arg from CI (the build context excludes .git/, so an
+# in-container `git describe` can't resolve it). Fall back to git describe for local
+# builds that include .git/, then to v0.0.0.
+ARG OM_SOFTWARE_VERSION=""
+RUN echo "export OM_SOFTWARE_VERSION=${OM_SOFTWARE_VERSION:-$(git describe --tags 2>/dev/null || git describe --always 2>/dev/null || echo v0.0.0)}" > version_info.env
 
 COPY ./docker/openmower_entrypoint.legacy.sh /openmower_entrypoint.sh
 RUN chmod +x /openmower_entrypoint.sh


### PR DESCRIPTION
Rebased/cleaned version of #331 onto current `main` (original branch had unrelated merge commits and reverted commits mixed in — this PR contains only the actual Docker versioning change).

### Problem
After updating to `main`, the reported version (app + MQTT `openmower/version` / `openmower/version/json`) shows `v0.0.0` instead of the real version.

### Root cause
#321 added a `.dockerignore` entry excluding `.git/` from the Docker build context, but the Dockerfiles still compute the version via `git describe` at build time. Without `.git`, that call fails and every image silently falls back to `v0.0.0`.

### Fix
- Added an `OM_SOFTWARE_VERSION` build-arg to both Dockerfiles, used when provided, falling back to `git describe` (local builds), then `v0.0.0`.
- CI now computes the version from git and passes it as a build-arg to all image variants.
- `.dockerignore` left untouched — `.git/` should stay out of the build context for caching.

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Docker images now include consistent software version metadata.
  * Version information uses available release identifiers with reliable fallback values when detailed history is unavailable.
  * Version metadata is applied consistently across current and legacy image builds.
  * Image versions are now more predictable and easier to identify across releases and build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->